### PR TITLE
Fix missing hamburger menu on page

### DIFF
--- a/components/StickyTopNav.css
+++ b/components/StickyTopNav.css
@@ -311,7 +311,7 @@
 }
 
 .hamburger-menu {
-  display: none;
+  display: flex;
   flex-direction: column;
   justify-content: center;
   gap: 4px;
@@ -590,9 +590,7 @@
     display: flex;
   }
   
-  .hamburger-menu {
-    display: flex;
-  }
+  /* .hamburger-menu already visible by default */
   
   .nav-search {
     display: none;

--- a/components/StickyTopNav.tsx
+++ b/components/StickyTopNav.tsx
@@ -275,7 +275,7 @@ export default function StickyTopNav() {
             </div>
 
             <button
-              className="hamburger-menu mobile-only"
+              className="hamburger-menu"
               onClick={() => setIsMenuOpen(!isMenuOpen)}
               aria-label="Toggle menu"
               aria-expanded={isMenuOpen}


### PR DESCRIPTION
Make the hamburger menu always visible at the top of the page by removing its mobile-only restriction.

---
<a href="https://cursor.com/background-agent?bcId=bc-336f8253-d716-4873-9ff4-92a0ec976ae7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-336f8253-d716-4873-9ff4-92a0ec976ae7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

