### PR TITLE
Fix overlapping header text on mobile site

### DIFF
--- a/app/critical-styles.tsx
+++ b/app/critical-styles.tsx
@@ -5,9 +5,15 @@ export const criticalStyles = `
     scroll-behavior: smooth;
   }
   
-  /* Reserve space for sticky header to avoid CLS */
-  header {
-    height: 64px;
+  /* Reserve space for sticky top navigation without constraining all headers */
+  body {
+    padding-top: 64px;
+  }
+  
+  @media (max-width: 480px) {
+    body {
+      padding-top: 56px;
+    }
   }
   
   /* Loading states */

--- a/app/globals.css
+++ b/app/globals.css
@@ -351,7 +351,6 @@ button, a, .clickable {
   min-height: 100vh;
   background: #f8f9fa;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-  padding-top: 64px; /* Add padding for the fixed header */
 }
 
 .guide-container {
@@ -945,7 +944,6 @@ section strong {
 
 @media (max-width: 768px) {
   .guide-page {
-    padding-top: 56px; /* Adjust for smaller header on mobile */
   }
 
   .guide-container {

--- a/src/components/StadiumGuide.css
+++ b/src/components/StadiumGuide.css
@@ -54,6 +54,23 @@
   box-shadow: 0 0.125rem 0.5rem rgba(0, 0, 0, 0.05);
 }
 
+/* Ensure meta row lays out correctly across devices */
+.stadium-meta {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  color: #495057;
+}
+
+.stadium-meta .location,
+.stadium-meta .capacity,
+.stadium-meta .opened {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
 .stadium-header h1 {
   font-size: clamp(1.75rem, 5vw, 2.5rem);
   font-weight: 700;
@@ -949,6 +966,17 @@
 /* Comprehensive Stadium Guide Styles */
 .stadium-guide.comprehensive {
   background: linear-gradient(to bottom, #f8f9fa, #ffffff);
+}
+
+/* Offset in-page anchors for sticky navigation */
+section[id] {
+  scroll-margin-top: 72px;
+}
+
+@media (max-width: 480px) {
+  section[id] {
+    scroll-margin-top: 60px;
+  }
 }
 
 .guide-section {


### PR DESCRIPTION
Remove fixed header height and add body padding to prevent header text overlap on mobile.

Previously, a global critical style fixed all header elements to 64px, causing large H1s on mobile to wrap and overlap subsequent content. This change allows headers to take their natural height while maintaining space for the sticky navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-82a8f342-acf9-44fc-a0fd-ac2f3567e472">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-82a8f342-acf9-44fc-a0fd-ac2f3567e472">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

