### PR TITLE
Phase 9 Track B: UX quick wins — game-window shade, fidelity disclosure, flow fixes

### DIFF
--- a/app/HomePage.tsx
+++ b/app/HomePage.tsx
@@ -19,12 +19,17 @@ export default function HomePage() {
 
   const handleCTAClick = () => {
     setShowApp(true);
+    // After the app reveals, land the user directly on the stadium picker and
+    // focus it so the next step is obvious — not the top of a section that can
+    // look empty. Falls back to the app section if the dynamic app hasn't
+    // finished mounting yet (focus is then simply skipped, no harm).
     setTimeout(() => {
-      const appElement = document.getElementById('app-section');
-      if (appElement) {
-        appElement.scrollIntoView({ behavior: 'smooth' });
-      }
-    }, 100);
+      const venueInput = document.getElementById('venue-select');
+      const target = venueInput?.closest('.control-group') || document.getElementById('app-section');
+      const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      target?.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'center' });
+      venueInput?.focus({ preventScroll: true });
+    }, 200);
   };
 
   return (

--- a/src/UnifiedApp.tsx
+++ b/src/UnifiedApp.tsx
@@ -9,6 +9,7 @@ import { SectionList } from './components/SectionList';
 import { EmptyState } from './components/EmptyStates';
 import { ErrorProvider, useError } from './components/ErrorNotification';
 import { Breadcrumb } from './components/Breadcrumb';
+import { FidelityNotice } from './components/FidelityNotice';
 import { LoadingSpinner } from './components/LoadingSpinner';
 import { VenueChangeSkeleton } from './components/SkeletonScreens';
 import { SunIcon, CloudIcon, ChartIcon, InfoIcon, MoonIcon, StadiumIcon, ShadeIcon, PartlyCloudyIcon, RainIcon } from './components/Icons';
@@ -329,6 +330,12 @@ function UnifiedAppContent() {
             onVenueChange={handleVenueChange}
             onGamesLoaded={setStadiumGames}
           />
+
+          {/* Honest disclosure for MLB parks whose seating data is templated.
+              Gated to MLB — the fidelity classifier is MLB-specific. */}
+          {selectedVenue?.league === 'MLB' && (
+            <FidelityNotice stadiumId={selectedVenue.id} />
+          )}
 
           {!selectedVenue && (
             <EmptyState 

--- a/src/components/ComprehensiveStadiumGuide.tsx
+++ b/src/components/ComprehensiveStadiumGuide.tsx
@@ -14,6 +14,7 @@ import {
 } from './Icons';
 import StadiumTitleBlock from './StadiumTitleBlock';
 import { StadiumTitleData } from './StadiumTitleBlock';
+import { FidelityNotice } from './FidelityNotice';
 import './StadiumGuide.css';
 
 interface ComprehensiveStadiumGuideProps {
@@ -70,6 +71,8 @@ const ComprehensiveStadiumGuide: React.FC<ComprehensiveStadiumGuideProps> = ({ s
         data={titleData}
         showBreadcrumb={true}
       />
+
+      <FidelityNotice stadiumId={stadiumId} />
 
       {/* Overview Section */}
       <section className="guide-section">

--- a/src/components/FidelityNotice.tsx
+++ b/src/components/FidelityNotice.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { getStadiumDataFidelity, fidelityNote } from '../data/stadiumDataFidelity';
+import { InfoIcon } from './Icons';
+
+interface FidelityNoticeProps {
+  /** Canonical MLB stadium id. Pass null/undefined to render nothing. */
+  stadiumId: string | null | undefined;
+}
+
+/**
+ * Subtle, honest disclosure for stadiums whose per-section seating data is
+ * approximate (the auto-generated bowl template) rather than a real seating
+ * map. Renders nothing for parks with real data. Single source of truth:
+ * src/data/stadiumDataFidelity.ts.
+ *
+ * NOTE: the fidelity classifier is MLB-specific, so only render this in MLB
+ * contexts (gate non-MLB callers, e.g. by venue.league === 'MLB').
+ */
+export const FidelityNotice: React.FC<FidelityNoticeProps> = ({ stadiumId }) => {
+  if (!stadiumId) return null;
+  const note = fidelityNote(getStadiumDataFidelity(stadiumId));
+  if (!note) return null;
+  return (
+    <div
+      className="fidelity-notice"
+      role="note"
+      style={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: '8px',
+        margin: '12px 0',
+        padding: '10px 14px',
+        background: '#f1f5f9',
+        border: '1px solid #e2e8f0',
+        borderRadius: '8px',
+        color: '#475569',
+        fontSize: '0.85rem',
+        lineHeight: 1.4,
+      }}
+    >
+      <span style={{ flexShrink: 0, marginTop: '1px', color: '#0052CC' }} aria-hidden="true">
+        <InfoIcon size={16} />
+      </span>
+      <span>{note}</span>
+    </div>
+  );
+};
+
+export default FidelityNotice;

--- a/src/components/GameWindowShade.tsx
+++ b/src/components/GameWindowShade.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import { MLB_STADIUMS } from '../data/stadiums';
+import { getStadiumSections } from '../data/stadium-data-aggregator';
+import {
+  calculateGameWindowShade,
+  gameWindowOffsets,
+  type SunSample,
+  type SectionWindowShade,
+} from '../utils/sunCalculator';
+import { getSunPosition } from '../utils/sunCalculations';
+import { stadiumLocalDateAndTimeToUTC } from '../utils/stadiumTime';
+
+interface GameWindowShadeProps {
+  stadiumId: string;
+  /** Stadium-local first-pitch time, "HH:MM". */
+  gameTime: string;
+  /** Game date (the weather code derives the same first-pitch instant from this). */
+  gameDate: Date;
+  /** Length of the game window in minutes (default 180 ≈ a pitch-clock game + margin). */
+  windowMinutes?: number;
+}
+
+// Compose a short, fan-readable summary of how shade migrates across the game.
+function describeStart(end: number): string {
+  return end >= 50 ? 'ends shaded' : 'ends sunny';
+}
+
+/**
+ * Surfaces the whole-game-window shade (Phase 9 A5): instead of a single
+ * instant, it samples the sun across the game and shows how each section moves
+ * between sun and shade — e.g. "shaded at first pitch → sunny by the 7th".
+ *
+ * Computed client-side with the SAME pure functions the API uses and the SAME
+ * first-pitch instant the weather panel derives (via stadiumLocalDateAndTimeToUTC),
+ * so there's no network round-trip and no timezone/date drift.
+ *
+ * Renders nothing for night games (sun already down across the window) or when
+ * the stadium isn't found.
+ */
+export const GameWindowShade: React.FC<GameWindowShadeProps> = ({
+  stadiumId,
+  gameTime,
+  gameDate,
+  windowMinutes = 180,
+}) => {
+  const model = useMemo(() => {
+    const stadium = MLB_STADIUMS.find((s) => s.id === stadiumId);
+    if (!stadium) return null;
+
+    const [h, m] = gameTime.split(':').map(Number);
+    if (Number.isNaN(h) || Number.isNaN(m)) return null;
+    const firstPitchUTC = stadiumLocalDateAndTimeToUTC(gameDate, h, m, stadium.timezone || 'UTC');
+
+    const offsets = gameWindowOffsets(windowMinutes, 30);
+    const samples: SunSample[] = offsets.map((min) => {
+      const t = new Date(firstPitchUTC.getTime() + min * 60_000);
+      const sp = getSunPosition(t, stadium.latitude, stadium.longitude);
+      return { minutesFromStart: min, altitudeDegrees: sp.altitudeDegrees, azimuthDegrees: sp.azimuthDegrees };
+    });
+
+    // Skip night games — "shaded" then just means the sun is down, which the
+    // single-instant view already conveys.
+    const sunUp = samples.some((s) => s.altitudeDegrees > 3);
+    if (!sunUp) return { night: true } as const;
+
+    const sections = getStadiumSections(stadiumId, 'MLB');
+    const windows = sections.map((s) => calculateGameWindowShade(s, samples, stadium.orientation || 0));
+
+    const count = (p: SectionWindowShade['progression']) =>
+      windows.filter((w) => w.progression === p).length;
+
+    // Sections that flip sun→shade are the actionable ones for fans who stay
+    // late; show a few, sorted by how dramatic the swing is.
+    const becomesShaded = windows
+      .filter((w) => w.progression === 'sun-to-shade')
+      .sort((a, b) => (b.endCoverage - b.startCoverage) - (a.endCoverage - a.startCoverage))
+      .slice(0, 4);
+    const becomesSunny = windows
+      .filter((w) => w.progression === 'shade-to-sun')
+      .sort((a, b) => (b.startCoverage - b.endCoverage) - (a.startCoverage - a.endCoverage))
+      .slice(0, 4);
+
+    return {
+      night: false as const,
+      windowMinutes,
+      shadedAll: count('shaded-all'),
+      sunnyAll: count('sunny-all'),
+      sunToShade: count('sun-to-shade'),
+      shadeToSun: count('shade-to-sun'),
+      becomesShaded,
+      becomesSunny,
+    };
+  }, [stadiumId, gameTime, gameDate, windowMinutes]);
+
+  if (!model || model.night) return null;
+
+  const hours = Math.round(model.windowMinutes / 60);
+
+  return (
+    <section className="mb-6 rounded-lg border border-amber-200 bg-amber-50 p-4" aria-labelledby="window-shade-title">
+      <h3 id="window-shade-title" className="text-lg font-semibold text-gray-900 mb-1">
+        ☀️ How shade moves during the game
+      </h3>
+      <p className="text-sm text-gray-600 mb-3">
+        The sun shifts ~15°/hour, so shade migrates over the ~{hours}-hour game. Based on first pitch through the final out.
+      </p>
+
+      <div className="flex flex-wrap gap-2 mb-3 text-sm">
+        <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-teal-100 text-teal-800">
+          {model.shadedAll} shaded all game
+        </span>
+        <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-blue-100 text-blue-800">
+          {model.sunToShade} sun → shade
+        </span>
+        <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-orange-100 text-orange-800">
+          {model.shadeToSun} shade → sun
+        </span>
+        <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-red-100 text-red-800">
+          {model.sunnyAll} sunny all game
+        </span>
+      </div>
+
+      {model.becomesShaded.length > 0 && (
+        <div className="mb-2">
+          <p className="text-sm font-medium text-gray-700">Good if you stay late (starts sunny → ends shaded):</p>
+          <ul className="text-sm text-gray-700 list-disc list-inside">
+            {model.becomesShaded.map((w) => (
+              <li key={w.sectionId}>
+                <span className="font-medium">{w.sectionName}</span>{' '}
+                — {Math.round(100 - w.startCoverage)}% sun at first pitch, {describeStart(w.endCoverage)} ({Math.round(w.endCoverage)}% covered) by the end
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {model.becomesSunny.length > 0 && (
+        <div>
+          <p className="text-sm font-medium text-gray-700">Best early, sunnier later (shade fades as the game goes):</p>
+          <ul className="text-sm text-gray-700 list-disc list-inside">
+            {model.becomesSunny.map((w) => (
+              <li key={w.sectionId}>
+                <span className="font-medium">{w.sectionName}</span>{' '}
+                — {Math.round(w.startCoverage)}% covered at first pitch, {Math.round(100 - w.endCoverage)}% sun by the end
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default GameWindowShade;

--- a/src/components/LazySectionCardModern.tsx
+++ b/src/components/LazySectionCardModern.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useIntersectionObserver } from '../hooks/useIntersectionObserver';
 import { useHapticFeedback } from '../hooks/useHapticFeedback';
 import type { StadiumSection } from '../data/stadiumSectionTypes';
-import { CloudIcon, PartlyCloudyIcon, SunIcon, FireIcon, FieldLevelIcon, LowerLevelIcon, ClubLevelIcon, UpperLevelIcon, CrownIcon } from './Icons';
+import { CloudIcon, PartlyCloudyIcon, SunIcon, FireIcon, FieldLevelIcon, LowerLevelIcon, ClubLevelIcon, UpperLevelIcon, CrownIcon, UmbrellaIcon } from './Icons';
 import { formatPercentageForScreenReader, announceToScreenReader } from '../utils/accessibility';
 
 interface LazySectionCardProps {
@@ -117,6 +117,13 @@ const LazySectionCardModernComponent: React.FC<LazySectionCardProps> = ({
               {section.level === 'suite' && <CrownIcon size={14} />}
               <span>{section.level.charAt(0).toUpperCase() + section.level.slice(1)} Level</span>
             </span>
+            {/* Covered = permanent shade from a roof/overhang, distinct from sun-angle shade */}
+            {section.covered && (
+              <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-medium bg-teal-100 text-teal-700">
+                <UmbrellaIcon size={14} />
+                <span>Covered (roof)</span>
+              </span>
+            )}
           </div>
 
           {/* Animated hover indicator */}

--- a/src/components/SeatRecommendationsSection.tsx
+++ b/src/components/SeatRecommendationsSection.tsx
@@ -4,6 +4,7 @@ import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import { SeatRecommendationEngine, UserPreferences, RecommendationContext } from '../services/seatRecommendationEngine';
 import { SeatingSectionSun } from '../utils/sunCalculations';
 import { SeatPreferencesForm } from './SeatPreferencesForm';
+import { GameWindowShade } from './GameWindowShade';
 import { LoadingSpinner } from './LoadingSpinner';
 import { MLB_STADIUMS } from '../data/stadiums';
 import { getStadiumCompleteData } from '../data/stadium-data-aggregator';
@@ -262,6 +263,9 @@ export const SeatRecommendationsSection: React.FC<SeatRecommendationsSectionProp
           </div>
         </div>
       </div>
+
+      {/* Whole-game-window shade: how sun/shade migrates across the game (A5). */}
+      <GameWindowShade stadiumId={stadiumId} gameTime={gameTime} gameDate={gameDate} />
 
       {/* Weather status — visible so users know if recommendations use real data */}
       {weatherLoading && (

--- a/src/components/SectionList.css
+++ b/src/components/SectionList.css
@@ -251,6 +251,30 @@
   margin: 8px 0;
 }
 
+.reset-filters-btn {
+  margin-top: 16px;
+  padding: 10px 20px;
+  min-height: 44px;
+  touch-action: manipulation;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #fff;
+  background: #0052CC;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.reset-filters-btn:hover {
+  background: #003d99;
+}
+
+.reset-filters-btn:focus-visible {
+  outline: 3px solid #0052CC;
+  outline-offset: 2px;
+}
+
 .section-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));

--- a/src/components/SectionList.tsx
+++ b/src/components/SectionList.tsx
@@ -353,14 +353,24 @@ export const SectionList: React.FC<SectionListProps> = ({
           {debouncedSearchTerm ? (
             <>
               <p>No sections found matching "{debouncedSearchTerm}".</p>
-              <p>Try a different search term or clear the search to see all sections.</p>
+              <p>Try a different search term, or reset to see every section.</p>
             </>
           ) : (
             <>
-              <p>No sections match your filter criteria.</p>
-              <p>Try adjusting your filters to see more results.</p>
+              <p>No sections match your current filters.</p>
+              <p>Your filters may be too restrictive — reset them to see every section.</p>
             </>
           )}
+          <button
+            type="button"
+            className="reset-filters-btn"
+            onClick={() => {
+              setSearchTerm('');
+              setFilters({ maxSunExposure: undefined, sectionType: [], priceRange: [] });
+            }}
+          >
+            Reset search &amp; filters
+          </button>
         </div>
       ) : (
         <div className="section-list-container" role="list" aria-labelledby="sections-title">

--- a/src/components/UnifiedGameSelector.tsx
+++ b/src/components/UnifiedGameSelector.tsx
@@ -584,6 +584,17 @@ export const UnifiedGameSelector: React.FC<UnifiedGameSelectorProps> = ({
                     <div className="no-games">
                       <p>{t('gameSelector.noGamesForStadium')}</p>
                       <p>{t('gameSelector.tryCustomTime')}</p>
+                      <button
+                        type="button"
+                        className="apply-custom-btn"
+                        onClick={() => {
+                          haptic.light();
+                          setViewMode('custom');
+                          preferencesStorage.update('viewMode', 'custom');
+                        }}
+                      >
+                        🕐 {t('gameSelector.customTime')}
+                      </button>
                     </div>
                   )
                 )}

--- a/src/data/__tests__/stadiumDataFidelity.test.ts
+++ b/src/data/__tests__/stadiumDataFidelity.test.ts
@@ -37,9 +37,9 @@ describe('classifyFidelity', () => {
 
 describe('getStadiumDataFidelity (real data)', () => {
   it('classifies the three authored parks as real', () => {
-    for (const id of REAL_DATA_STADIUMS) {
+    Array.from(REAL_DATA_STADIUMS).forEach((id) => {
       expect(getStadiumDataFidelity(id)).toBe('real');
-    }
+    });
   });
 
   it('classifies a known template park as approximate', () => {

--- a/todo.md
+++ b/todo.md
@@ -78,16 +78,26 @@ final out. A single-instant answer is precisely accurate for a moment that's wro
 
 ---
 
-## TRACK B — UX quick wins
+## TRACK B — UX quick wins ✅ COMPLETE
 
-- [ ] **Hero → app:** CTA scrolls into an empty-looking app; make the venue selector immediately visible/auto-focused (`HomePage.tsx`, `UnifiedGameSelector.tsx`).
-- [ ] **Off-season dead-end:** when a venue has no upcoming games, prominently surface the custom date/time picker instead of a generic empty state (`UnifiedApp.tsx`/`EmptyStates.tsx`).
-- [ ] **Reset filters:** add a "Reset filters" button + clearer zero-results explanation in `SectionList.tsx`.
-- [ ] **Weather copy:** clarify sun position is still accurate when the >7-day forecast is unavailable (`WeatherDisplay.tsx`).
-- [ ] **Roofed vs shaded:** distinct roof icon/label so permanently-covered sections read differently from sun-shaded ones.
-- [ ] **Surface game-window shade (A5):** have the app request `window` and show shade *migration* — e.g. "shaded at first pitch → sunny by the 7th" and a small timeline — instead of a single-instant verdict. This is where the A5 accuracy gain becomes user-visible.
-- [ ] **Disclose fidelity:** subtle "approximate seating data" note on `approximate` stadiums, reading `getStadiumDataFidelity` from A3.
-- [ ] Run the `web-design-guidelines` review over touched components.
+- [x] **Hero → app:** `HomePage.tsx` CTA now scrolls to and focuses the stadium picker (`#venue-select`, centered) instead of the app-section top, falling back gracefully if the dynamic app hasn't mounted. The next step is now obvious.
+- [x] **Off-season dead-end:** the MLB/MiLB "no games" message in `UnifiedGameSelector.tsx` now has a "🕐 Custom time" button that switches to the custom date/time tab (reuses in-scope `setViewMode`/`haptic`/`apply-custom-btn`).
+- [x] **Reset filters:** added "Reset search & filters" button + clearer zero-results copy in `SectionList.tsx` (resets `searchTerm` + `filters`); styled `.reset-filters-btn` in `SectionList.css`.
+- [x] **Weather copy:** already correct — `WeatherDisplay.tsx:96` already states "Sun position calculations are still accurate and based on astronomical data." No change needed.
+- [x] **Roofed vs shaded:** added a distinct teal `UmbrellaIcon` "Covered (roof)" badge in `LazySectionCardModern.tsx` (was only in the aria-label), so permanent-shade sections read differently from sun-angle shade.
+- [x] **Surface game-window shade (A5):** new `GameWindowShade.tsx` shows shade *migration* ("starts sunny → ends shaded", per-progression counts + the most-dramatic transitioning sections). Computed **client-side** with the same pure functions the API uses and the same first-pitch instant the weather panel derives (`stadiumLocalDateAndTimeToUTC`) — no HTTP round-trip, no timezone/date drift (the route's date-string handling has a latent western-tz off-by-one I sidestepped). Guards night games. Wired into `SeatRecommendationsSection.tsx`. Verified: evening game → 49 sun→shade sections; day game → stable; night → renders nothing.
+- [x] **Disclose fidelity:** new reusable `FidelityNotice.tsx` (reads `getStadiumDataFidelity`/`fidelityNote` from A3); wired into both flows — `UnifiedApp.tsx` (gated `league==='MLB'`) + `ComprehensiveStadiumGuide.tsx`. Renders nothing for real-data parks.
+- [x] Fixed a Track-A carryover: `stadiumDataFidelity.test.ts` iterated a `ReadonlySet` (tsc-target error, passed only in Jest) → `Array.from`. Restores `npm run type-check` for that file.
+- [x] Ran the `web-design-guidelines` review over touched components. Findings were minor; applied the two worthwhile fixes: HomePage CTA scroll now honors `prefers-reduced-motion`, and `.reset-filters-btn` got `touch-action: manipulation`. All buttons are native `<button>` with hover/focus states; new panels use `aria-labelledby`/`role`, AA contrast, and text+color (not color-only).
+
+## Review — Track B complete (2026-06-23)
+
+All 7 UX quick wins shipped (weather copy was already correct). Each change is a minimal, surgical insertion into
+a confirmed-live component — no refactors, no dead-code edits. New components: `FidelityNotice.tsx` (A3 disclosure,
+both flows), `GameWindowShade.tsx` (A5 payoff, client-side compute). Edits: `HomePage.tsx` (CTA focus + reduced-motion),
+`UnifiedGameSelector.tsx` (off-season → custom-time button), `SectionList.tsx`/`.css` (reset-filters), `LazySectionCardModern.tsx`
+(covered-roof badge), `UnifiedApp.tsx` + `ComprehensiveStadiumGuide.tsx` (fidelity wiring). Plus a Track-A `tsc` carryover fix.
+All touched files type-check clean; game-window output sanity-verified for evening/day/night.
 
 ### Documented follow-ups (NOT this pass)
 Game-selection persistence per venue; smarter contextual empty states; mobile menu scroll-lock on iOS; UV


### PR DESCRIPTION
## Summary

Surfaces the Track A accuracy work in the UI and fixes the intuitiveness rough edges from the audit. Every change is a minimal, surgical insertion into a **confirmed-live** component — no refactors, no dead-code edits.

### New components
- **`GameWindowShade.tsx`** — surfaces the A5 whole-game-window shade: how each section moves between sun and shade across the game ("starts sunny → ends shaded"), with per-progression counts and the most-dramatic transitioning sections. Computed **client-side** with the same pure functions the API uses (`calculateGameWindowShade`/`gameWindowOffsets`/`getSunPosition`) and the **same first-pitch instant the weather panel derives** (`stadiumLocalDateAndTimeToUTC`) — so there's no HTTP round-trip and no timezone/date drift (the route's date-string handling has a latent western-tz off-by-one this sidesteps). Guards night games.
- **`FidelityNotice.tsx`** — honest "approximate seating data" disclosure reading `getStadiumDataFidelity`/`fidelityNote` from Track A's A3. Renders nothing for the 3 real-data parks.

### Edits
- **`HomePage.tsx`** — CTA scrolls to + focuses the stadium picker (`#venue-select`), honoring `prefers-reduced-motion`, instead of an empty-looking section top.
- **`UnifiedGameSelector.tsx`** — off-season "no games" now offers a "🕐 Custom time" button → date/time picker, instead of dead-ending.
- **`SectionList.tsx` / `.css`** — "Reset search & filters" button + clearer zero-results copy (`.reset-filters-btn` with `:focus-visible`, 44px target, `touch-action`).
- **`LazySectionCardModern.tsx`** — visible teal "Covered (roof)" badge (was aria-label only) so permanent-shade reads differently from sun-angle shade.
- **`UnifiedApp.tsx` + `ComprehensiveStadiumGuide.tsx`** — fidelity disclosure wiring (homepage app is MLB-gated).
- Fix Track-A carryover: `stadiumDataFidelity.test.ts` iterated a `ReadonlySet` (`tsc`-target error; passed only in Jest) → `Array.from`, restoring `npm run type-check`.

## Verification
- All touched files **type-check clean** (no new errors)
- `web-design-guidelines` review run; applied 2 minor fixes (reduced-motion scroll, `touch-action`). All buttons native `<button>` with hover/focus; new panels use `aria-labelledby`/`role`, AA contrast, text+color (not color-only).
- Game-window output sanity-checked: evening game → 49 sun→shade sections; day game → stable; night game → renders nothing.

## Note
Weather copy (audit item) was already correct (`WeatherDisplay.tsx:96`) — no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)