### PR TITLE
Fix type-check/build: park untracked half-built WIP out of the build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ bundle-analysis.txt
 test-results.json
 *_analysis.txt
 stadium_verification*.log
+
+# Parked half-built WIP (World Cup 2026, admin) — moved out of the build 2026-06-23, see _wip/README.md
+_wip/

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules", "dev-scripts"]
+  "exclude": ["node_modules", "dev-scripts", "_wip"]
 }


### PR DESCRIPTION
## Summary

`npm run type-check` and `npm run build` were broken locally by **untracked, half-built WIP** unrelated to the sun-tracker:
- **World Cup 2026** pages importing `src/data/worldcup2026/{venues,matches,types}` + `src/components/worldcup/*` (7 components) — none of which exist.
- **Admin analytics** needing the `lucide-react` dep and a `src/data/stadium-data-freshness` module.
- 4 orphan `components/` files (incl. `VenueSelector` referencing a `country` field not on `UnifiedVenue`).

Nothing in the committed codebase referenced any of it.

## Change
- Moved all 26 WIP files into `_wip/` (preserved exactly, documented in `_wip/README.md`).
- Excluded `_wip` from `tsconfig.json`; added `_wip/` to `.gitignore`.

Only two tracked files change (`tsconfig.json`, `.gitignore`). Resuming the WIP later = move a folder back and build out the imports it references.

## Verification
- `npm run type-check` → **0 errors**
- `npm run build` → **✓ Compiled successfully, 272/272 static pages**
- Real API routes and the live app are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)