### PR TITLE
PWA: silent auto-update, remove "Update Available" popup, reconcile SW paths

### DIFF
--- a/components/PWAInstallPrompt.tsx
+++ b/components/PWAInstallPrompt.tsx
@@ -13,7 +13,9 @@ interface BeforeInstallPromptEvent extends Event {
 export default function PWAInstallPrompt() {
   const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
   const [showPrompt, setShowPrompt] = useState(false);
-  const [showUpdatePrompt, setShowUpdatePrompt] = useState(false);
+  // Update notifications are intentionally NOT handled here. The app
+  // auto-updates silently — see components/ServiceWorkerRegistration.tsx, the
+  // single owner of service-worker registration + update behavior.
 
   useEffect(() => {
     // Handle PWA install prompt
@@ -28,24 +30,10 @@ export default function PWAInstallPrompt() {
     };
 
 
-    // Handle service worker updates
-    const handleServiceWorkerUpdate = () => {
-      setShowUpdatePrompt(true);
-    };
-
     window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
-
-    // Check for service worker updates
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.addEventListener('controllerchange', handleServiceWorkerUpdate);
-    }
 
     return () => {
       window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
-      
-      if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.removeEventListener('controllerchange', handleServiceWorkerUpdate);
-      }
     };
   }, []);
 
@@ -70,22 +58,6 @@ export default function PWAInstallPrompt() {
     setDeferredPrompt(null);
   };
 
-  const handleUpdateClick = () => {
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.getRegistration().then((registration) => {
-        if (registration?.waiting) {
-          registration.waiting.postMessage({ type: 'SKIP_WAITING' });
-        }
-      });
-    }
-    setShowUpdatePrompt(false);
-    window.location.reload();
-  };
-
-  const handleDismissUpdate = () => {
-    setShowUpdatePrompt(false);
-  };
-
   return (
     <>
       {/* PWA Install Prompt */}
@@ -95,19 +67,6 @@ export default function PWAInstallPrompt() {
           <button onClick={handleInstallClick}>Install</button>
           <button className="close-btn" onClick={handleDismissInstall}>
             ✕
-          </button>
-        </div>
-      )}
-
-
-      {/* Update Available Notification */}
-      {showUpdatePrompt && (
-        <div className="update-available">
-          <h4>🔄 Update Available</h4>
-          <p>A new version of The Shadium is available!</p>
-          <button onClick={handleUpdateClick}>Update Now</button>
-          <button className="dismiss-btn" onClick={handleDismissUpdate}>
-            Later
           </button>
         </div>
       )}

--- a/components/ServiceWorkerRegistration.tsx
+++ b/components/ServiceWorkerRegistration.tsx
@@ -26,6 +26,13 @@ export default function ServiceWorkerRegistration() {
     const SW_VERSION_KEY = 'shadium_sw_version';
     const CURRENT_SW_VERSION = 'v2';
 
+    // Whether a service worker already controls this page at mount. A later
+    // `controllerchange` then means a NEW worker took over (a genuine update),
+    // not the first-ever install — so we only auto-refresh in that case, and
+    // never on a brand-new visit (which would be a pointless reload).
+    const hadController = !!navigator.serviceWorker.controller;
+    let reloading = false;
+
     async function registerSW() {
       // If this is the first time a user runs v2, clean up the old v1 Workbox SW
       // (which had a stale precache manifest causing InvalidStateError).
@@ -46,25 +53,15 @@ export default function ServiceWorkerRegistration() {
 
         console.log('Service Worker registered with scope:', registration.scope);
 
-        // Periodically check for SW updates (every 60 s)
+        // Periodically check for SW updates (every 60 s). When a new sw.js is
+        // found, the worker calls skipWaiting()/clients.claim() and takes over
+        // immediately, which fires the `controllerchange` handler below — that
+        // performs the silent refresh. No user prompt is involved.
         const updateInterval = setInterval(() => {
           registration.update().catch(() => {
             // Update checks may fail offline — that's fine
           });
         }, 60_000);
-
-        // Handle the new SW installing
-        registration.addEventListener('updatefound', () => {
-          const newWorker = registration.installing;
-          if (!newWorker) return;
-
-          newWorker.addEventListener('statechange', () => {
-            if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-              console.log('New service worker available');
-              window.dispatchEvent(new Event('sw-update-available'));
-            }
-          });
-        });
 
         // Clean up interval if the component ever unmounts (SSR safety)
         return () => clearInterval(updateInterval);
@@ -89,9 +86,14 @@ export default function ServiceWorkerRegistration() {
       window.addEventListener('load', registerSW, { once: true });
     }
 
-    // Handle controller change (SW activated after update)
+    // Silent auto-update: when a new service worker takes control of the page,
+    // refresh once so the page runs the new version. Guarded so it never fires
+    // on the first install and never loops. Users never see a prompt or have to
+    // choose to update.
     navigator.serviceWorker.addEventListener('controllerchange', () => {
-      console.log('Service Worker controller changed');
+      if (!hadController || reloading) return;
+      reloading = true;
+      window.location.reload();
     });
   }, []);
 

--- a/src/UnifiedApp.tsx
+++ b/src/UnifiedApp.tsx
@@ -31,7 +31,6 @@ import { WeatherForecast, weatherApi } from './services/weatherApi';
 import { formatDateTimeWithTimezone } from './utils/timeUtils';
 import { performanceMonitor, trackWebVitals } from './utils/performanceMonitor';
 import { OfflineIndicator } from './components/OfflineIndicator';
-import * as serviceWorkerRegistration from './utils/serviceWorkerRegistration';
 import { trackStadiumSelection, trackGameSelection } from './utils/analytics';
 import { getUnifiedVenueShade, ShadedVenueSection } from './utils/getUnifiedVenueShade';
 

--- a/src/utils/serviceWorkerRegistration.ts
+++ b/src/utils/serviceWorkerRegistration.ts
@@ -1,171 +1,11 @@
-// Service Worker Registration Utility
-// Handles registration and communication with the service worker
-
-export interface SWConfig {
-  onSuccess?: (registration: ServiceWorkerRegistration) => void;
-  onUpdate?: (registration: ServiceWorkerRegistration) => void;
-  onError?: (error: Error) => void;
-  onOffline?: () => void;
-  onOnline?: () => void;
-}
-
-const isLocalhost = Boolean(
-  window.location.hostname === 'localhost' ||
-  window.location.hostname === '[::1]' ||
-  window.location.hostname.match(
-    /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
-  )
-);
-
-export function register(config?: SWConfig) {
-  if ('serviceWorker' in navigator) {
-    // The URL constructor is available in all browsers that support SW.
-    const publicUrl = new URL(process.env.PUBLIC_URL || '', window.location.href);
-    if (publicUrl.origin !== window.location.origin) {
-      // Our service worker won't work if PUBLIC_URL is on a different origin
-      return;
-    }
-
-    window.addEventListener('load', () => {
-      const swUrl = `${process.env.PUBLIC_URL || ''}/sw.js`;
-
-      if (isLocalhost) {
-        // This is running on localhost. Check if a service worker still exists or not.
-        checkValidServiceWorker(swUrl, config);
-
-        // Add some additional logging so developers can see what's happening
-        navigator.serviceWorker.ready.then(() => {
-
-          // Load service worker extensions after main SW is ready
-          if (navigator.serviceWorker.controller) {
-            navigator.serviceWorker.controller.postMessage({ type: 'LOAD_EXTENSIONS' });
-          }
-        });
-      } else {
-        // Is not localhost. Just register service worker
-        registerValidSW(swUrl, config);
-      }
-    });
-
-    // Listen for online/offline events
-    window.addEventListener('online', () => {
-
-      config?.onOnline?.();
-      
-      // Trigger background sync if available
-      navigator.serviceWorker.ready.then((registration) => {
-        if ('sync' in registration) {
-          (registration as any).sync.register('mlb-sync-preferences').catch((error: Error) => {
-
-          });
-        }
-      });
-    });
-
-    window.addEventListener('offline', () => {
-
-      config?.onOffline?.();
-    });
-
-    // Listen for messages from service worker
-    navigator.serviceWorker.addEventListener('message', (event) => {
-      if (event.data && event.data.type === 'SYNC_COMPLETE') {
-
-        // Notify the app that preferences were synced
-        window.dispatchEvent(new CustomEvent('sw-sync-complete', { detail: event.data.data }));
-      }
-    });
-  }
-}
-
-function registerValidSW(swUrl: string, config?: SWConfig) {
-  navigator.serviceWorker
-    .register(swUrl)
-    .then((registration) => {
-      // Request periodic background sync for weather updates
-      if ('periodicSync' in registration) {
-        (registration as any).periodicSync.register({
-          tag: 'update-weather',
-          minInterval: 30 * 60 * 1000, // 30 minutes
-        }).catch((error: Error) => {
-
-        });
-      }
-
-      registration.onupdatefound = () => {
-        const installingWorker = registration.installing;
-        if (installingWorker == null) {
-          return;
-        }
-        installingWorker.onstatechange = () => {
-          if (installingWorker.state === 'installed') {
-            if (navigator.serviceWorker.controller) {
-              // At this point, the updated precached content has been fetched,
-              // but the previous service worker will still serve the older
-              // content until all client tabs are closed.
-
-              // Execute callback
-              if (config && config.onUpdate) {
-                config.onUpdate(registration);
-              }
-            } else {
-              // At this point, everything has been precached.
-
-              // Execute callback
-              if (config && config.onSuccess) {
-                config.onSuccess(registration);
-              }
-            }
-          }
-        };
-      };
-    })
-    .catch((error) => {
-      console.error('Error during service worker registration:', error);
-      config?.onError?.(error);
-    });
-}
-
-function checkValidServiceWorker(swUrl: string, config?: SWConfig) {
-  // Check if the service worker can be found. If it can't reload the page.
-  fetch(swUrl, {
-    headers: { 'Service-Worker': 'script' },
-  })
-    .then((response) => {
-      // Ensure service worker exists, and that we really are getting a JS file.
-      const contentType = response.headers.get('content-type');
-      if (
-        response.status === 404 ||
-        (contentType != null && contentType.indexOf('javascript') === -1)
-      ) {
-        // No service worker found. Probably a different app. Reload the page.
-        navigator.serviceWorker.ready.then((registration) => {
-          registration.unregister().then(() => {
-            window.location.reload();
-          });
-        });
-      } else {
-        // Service worker found. Proceed as normal.
-        registerValidSW(swUrl, config);
-      }
-    })
-    .catch(() => {
-
-      config?.onOffline?.();
-    });
-}
-
-export function unregister() {
-  if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.ready
-      .then((registration) => {
-        registration.unregister();
-      })
-      .catch((error) => {
-        console.error(error.message);
-      });
-  }
-}
+// Service Worker helper utilities.
+//
+// NOTE: service-worker REGISTRATION and the silent auto-update behavior live in
+// the single owner `components/ServiceWorkerRegistration.tsx` (mounted in the
+// root layout). This file used to contain a second, competing CRA-style
+// `register()` path with its own update prompt — that was dead code (nothing
+// called it) and was removed when the registration paths were reconciled.
+// This file now holds only SW-adjacent helpers (offline state, cache info).
 
 // Helper function to cache a specific stadium's data
 export async function cacheStadiumData(stadiumId: string): Promise<void> {
@@ -175,7 +15,7 @@ export async function cacheStadiumData(stadiumId: string): Promise<void> {
 
   return new Promise((resolve, reject) => {
     const messageChannel = new MessageChannel();
-    
+
     messageChannel.port1.onmessage = (event) => {
       if (event.data.type === 'CACHE_COMPLETE') {
         resolve();
@@ -210,10 +50,10 @@ export async function getCacheInfo(): Promise<{
     const usage = estimate.usage || 0;
     const quota = estimate.quota || 0;
     const percentage = quota > 0 ? (usage / quota) * 100 : 0;
-    
+
     return { usage, quota, percentage };
   }
-  
+
   return { usage: 0, quota: 0, percentage: 0 };
 }
 


### PR DESCRIPTION
## Problem

The site showed an **"🔄 Update Available"** popup asking users to click "Update Now". Goal: updates should apply **silently** — no popup, no user choice.

Root cause: `PWAInstallPrompt.tsx` showed the popup on **any** `controllerchange` with **no guard**, so it fired even on a first-ever visit (when the SW first `clients.claim()`s an uncontrolled page) — a false "update available". There were also two registration paths and a dead `sw-update-available` event with no listener.

## Changes

- **`components/ServiceWorkerRegistration.tsx`** (the single registration owner) now does a one-time **silent page refresh** on a genuine controller change, guarded by `hadController` (skips the first-install claim) and a `reloading` flag (no loop). Removed the dead `sw-update-available` dispatch.
- **`components/PWAInstallPrompt.tsx`** — removed the entire update prompt (state, `controllerchange` listener, handlers, JSX). The "📱 Install" prompt stays.
- **`src/utils/serviceWorkerRegistration.ts`** — deleted the dead, competing CRA-style `register()`/`registerValidSW()`/`checkValidServiceWorker()` path (zero callers); kept the SW helper utilities (`isOffline`/`getCacheInfo`/etc.).
- **`src/UnifiedApp.tsx`** — removed the dead import of that module.

## Why this fully solves it

- The false positive (popup on first visit) is fixed by the `hadController` guard.
- Normal content deploys already reach users automatically — the SW serves HTML **network-first** (always fresh) and `/_next/static/` assets are content-hashed (new content = new URL = fetched fresh). No popup/reload was ever needed there.
- The rare case (`sw.js` itself changing, like the v1→v2 rewrite that caused the popup) now applies via a silent auto-reload instead of a prompt.

## Verification
- `npm run type-check` clean; production build compiles (272/272 pages)
- No dangling references to removed symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)