### PR TITLE
Fix pre-existing test-suite debt (0→666 green tracked tests)

### DIFF
--- a/components/__tests__/OptimizedImage.test.tsx
+++ b/components/__tests__/OptimizedImage.test.tsx
@@ -1,14 +1,17 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import OptimizedImage from '../OptimizedImage';
 
 // Mock Next.js Image component
 jest.mock('next/image', () => ({
   __esModule: true,
-  default: (props: any) => {
+  default: ({ fill, ...props }: any) => {
+    // Next's <Image fill> is a special boolean prop, not a DOM attribute — React
+    // drops a boolean `fill` off a raw <img>. Mirror it as a string attribute so
+    // tests can assert the component opted into fill mode.
     // eslint-disable-next-line jsx-a11y/alt-text
-    return <img {...props} />;
+    return <img {...props} {...(fill ? { fill: 'true' } : {})} />;
   },
 }));
 
@@ -34,6 +37,28 @@ describe('OptimizedImage', () => {
     });
   });
 
+  // OptimizedImage lazy-loads the <img> only once it scrolls into view (unless
+  // `priority`). Tests that assert on the rendered <img> must first simulate the
+  // element entering the viewport, exactly as the component's IntersectionObserver
+  // callback would. Wrapped in act() so the resulting state update + re-render flush.
+  const enterView = () =>
+    act(() => {
+      observerCallback(
+        [
+          {
+            isIntersecting: true,
+            target: document.body,
+            boundingClientRect: {} as DOMRectReadOnly,
+            intersectionRatio: 1,
+            intersectionRect: {} as DOMRectReadOnly,
+            rootBounds: null,
+            time: Date.now(),
+          },
+        ],
+        mockObserver
+      );
+    });
+
   it('renders with basic props', () => {
     render(
       <OptimizedImage
@@ -44,7 +69,7 @@ describe('OptimizedImage', () => {
       />
     );
 
-    // Image should be in placeholder state initially
+    enterView();
     const container = screen.getByRole('img').parentElement;
     expect(container).toHaveClass('image-container');
   });
@@ -109,6 +134,7 @@ describe('OptimizedImage', () => {
       />
     );
 
+    enterView();
     const container = screen.getByRole('img').parentElement;
     expect(container).toHaveClass('image-container', 'custom-class');
   });
@@ -121,6 +147,7 @@ describe('OptimizedImage', () => {
       />
     );
 
+    enterView();
     const img = screen.getByRole('img');
     expect(img).toHaveAttribute('fill', 'true');
     expect(img.style.objectFit).toBe('cover');
@@ -137,6 +164,7 @@ describe('OptimizedImage', () => {
       />
     );
 
+    enterView();
     const img = screen.getByRole('img');
     expect(img).toHaveAttribute('quality', '85');
   });
@@ -155,6 +183,7 @@ describe('OptimizedImage', () => {
       />
     );
 
+    enterView();
     const img = screen.getByRole('img');
     expect(img).toHaveAttribute('blurDataURL', blurDataURL);
   });
@@ -170,6 +199,7 @@ describe('OptimizedImage', () => {
       />
     );
 
+    enterView();
     const img = screen.getByRole('img');
     expect(img).toHaveAttribute('blurDataURL');
     expect(img.getAttribute('blurDataURL')).toContain('data:image/svg+xml;base64');
@@ -188,6 +218,7 @@ describe('OptimizedImage', () => {
       />
     );
 
+    enterView();
     const img = screen.getByRole('img');
     expect(img).toHaveAttribute('sizes', sizes);
   });
@@ -264,21 +295,7 @@ describe('OptimizedImage', () => {
       />
     );
 
-    // Simulate intersection to load image
-    observerCallback(
-      [
-        {
-          isIntersecting: true,
-          target: document.body,
-          boundingClientRect: {} as DOMRectReadOnly,
-          intersectionRatio: 1,
-          intersectionRect: {} as DOMRectReadOnly,
-          rootBounds: null,
-          time: Date.now(),
-        },
-      ],
-      mockObserver
-    );
+    enterView();
 
     const img = screen.getByRole('img');
     expect(img).toHaveAttribute('loading', 'lazy');

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,12 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': ['ts-jest', {
       tsconfig: {
-        jsx: 'react',
+        // 'react-jsx' = the automatic JSX runtime (react/jsx-runtime), matching
+        // how Next.js builds these components. The old 'react' (classic) runtime
+        // compiled JSX to React.createElement and required `import React` in every
+        // component — which the components don't do — causing
+        // "ReferenceError: React is not defined" in component render tests.
+        jsx: 'react-jsx',
         esModuleInterop: true,
         allowSyntheticDefaultImports: true,
         moduleResolution: 'node',

--- a/src/data/__tests__/stadiumDataIntegrity.test.ts
+++ b/src/data/__tests__/stadiumDataIntegrity.test.ts
@@ -163,7 +163,7 @@ function validateObstruction(obstruction: any, fileName: string): string[] {
 
 describe('Stadium Data Integrity Tests', () => {
   describe('Section Files Validation', () => {
-    const sectionsDir = path.join(__dirname, '../../sections');
+    const sectionsDir = path.join(__dirname, '../sections');
     const sectionFiles = fs.existsSync(sectionsDir) ? findTsFiles(sectionsDir) : [];
     
     test('All section files exist', () => {
@@ -210,7 +210,7 @@ describe('Stadium Data Integrity Tests', () => {
   });
   
   describe('Obstruction Files Validation', () => {
-    const obstructionsDir = path.join(__dirname, '../../obstructions');
+    const obstructionsDir = path.join(__dirname, '../obstructions');
     const obstructionFiles = fs.existsSync(obstructionsDir) ? findTsFiles(obstructionsDir) : [];
     
     test('All obstruction files exist', () => {
@@ -258,7 +258,7 @@ describe('Stadium Data Integrity Tests', () => {
   
   describe('Data Consistency Checks', () => {
     test('No duplicate section IDs within files', () => {
-      const sectionsDir = path.join(__dirname, '../../sections');
+      const sectionsDir = path.join(__dirname, '../sections');
       if (!fs.existsSync(sectionsDir)) return;
       
       const sectionFiles = findTsFiles(sectionsDir);
@@ -291,7 +291,7 @@ describe('Stadium Data Integrity Tests', () => {
     
     test('All sections have unique 3D positions', () => {
       // Sections should not overlap exactly in 3D space
-      const sectionsDir = path.join(__dirname, '../../sections');
+      const sectionsDir = path.join(__dirname, '../sections');
       if (!fs.existsSync(sectionsDir)) return;
       
       const sectionFiles = findTsFiles(sectionsDir);
@@ -318,7 +318,7 @@ describe('Stadium Data Integrity Tests', () => {
   
   describe('Performance Validation', () => {
     test('Section files are not too large', () => {
-      const sectionsDir = path.join(__dirname, '../../sections');
+      const sectionsDir = path.join(__dirname, '../sections');
       if (!fs.existsSync(sectionsDir)) return;
       
       const sectionFiles = findTsFiles(sectionsDir);
@@ -340,7 +340,7 @@ describe('Stadium Data Integrity Tests', () => {
     });
     
     test('Obstruction complexity is reasonable', () => {
-      const obstructionsDir = path.join(__dirname, '../../obstructions');
+      const obstructionsDir = path.join(__dirname, '../obstructions');
       if (!fs.existsSync(obstructionsDir)) return;
       
       const obstructionFiles = findTsFiles(obstructionsDir);

--- a/src/data/sections/mlb/american-family-field.ts
+++ b/src/data/sections/mlb/american-family-field.ts
@@ -426,7 +426,7 @@ export const americanFamilyFieldSections: DetailedSection[] = [
   },
   // Brewers Bar
   {
-    id: 'brewers-bar',
+    id: 'brewers-bar-2',
     name: 'Brewers Bar',
     level: 'club',
     baseAngle: 315,
@@ -468,7 +468,7 @@ export const americanFamilyFieldSections: DetailedSection[] = [
   },
   // Uecker Seats
   {
-    id: 'uecker-seats',
+    id: 'uecker-seats-2',
     name: 'Uecker Seats',
     level: 'upper',
     baseAngle: 135,

--- a/src/data/sections/mlb/comerica-park.ts
+++ b/src/data/sections/mlb/comerica-park.ts
@@ -467,7 +467,7 @@ export const comericaParkSections: DetailedSection[] = [
   },
   // Pepsi Porch
   {
-    id: 'pepsi-porch',
+    id: 'pepsi-porch-2',
     name: 'Pepsi Porch',
     level: 'upper',
     baseAngle: 90,

--- a/src/data/sections/mlb/globe-life-field.ts
+++ b/src/data/sections/mlb/globe-life-field.ts
@@ -421,7 +421,7 @@ export const globeLifeFieldSections: DetailedSection[] = [
   },
   // Karbach Sky Porch
   {
-    id: 'karbach-sky-porch',
+    id: 'karbach-sky-porch-2',
     name: 'Karbach Sky Porch',
     level: 'upper',
     baseAngle: 225,
@@ -442,7 +442,7 @@ export const globeLifeFieldSections: DetailedSection[] = [
   },
   // Captain Morgan Club
   {
-    id: 'captain-morgan-club',
+    id: 'captain-morgan-club-2',
     name: 'Captain Morgan Club',
     level: 'club',
     baseAngle: 315,

--- a/src/data/sections/mlb/kauffman-stadium.ts
+++ b/src/data/sections/mlb/kauffman-stadium.ts
@@ -447,7 +447,7 @@ export const kauffmanStadiumSections: DetailedSection[] = [
   },
   // Craft & Draft
   {
-    id: 'craft-and-draft',
+    id: 'craft-and-draft-2',
     name: 'Craft & Draft',
     level: 'field',
     baseAngle: 225,
@@ -468,7 +468,7 @@ export const kauffmanStadiumSections: DetailedSection[] = [
   },
   // Crown Club
   {
-    id: 'crown-club',
+    id: 'crown-club-2',
     name: 'Crown Club',
     level: 'club',
     baseAngle: 0,

--- a/src/data/sections/mlb/nationals-park.ts
+++ b/src/data/sections/mlb/nationals-park.ts
@@ -404,7 +404,7 @@ export const nationalsParkSections: DetailedSection[] = [
   },
   // PNC Diamond Club
   {
-    id: 'pnc-diamond-club',
+    id: 'pnc-diamond-club-2',
     name: 'PNC Diamond Club',
     level: 'field',
     baseAngle: 0,
@@ -442,7 +442,7 @@ export const nationalsParkSections: DetailedSection[] = [
   },
   // Norfolk Southern Club
   {
-    id: 'norfolk-southern-club',
+    id: 'norfolk-southern-club-2',
     name: 'Norfolk Southern Club',
     level: 'club',
     baseAngle: 45,

--- a/src/data/sections/mlb/rogers-centre.ts
+++ b/src/data/sections/mlb/rogers-centre.ts
@@ -404,7 +404,7 @@ export const rogersCentreSections: DetailedSection[] = [
   },
   // WestJet Flight Deck
   {
-    id: 'westjet-flight-deck',
+    id: 'westjet-flight-deck-2',
     name: 'WestJet Flight Deck',
     level: 'upper',
     baseAngle: 135,

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -43,25 +43,29 @@ Object.defineProperty(window, 'matchMedia', {
   })),
 });
 
-// Mock navigator
-Object.defineProperty(window, 'navigator', {
+// Mock ONLY navigator.serviceWorker — do NOT replace the whole navigator.
+// Previously this spread `...window.navigator` into a new object, but Navigator
+// properties (userAgent, onLine, language, …) are prototype getters that a
+// spread does NOT copy, leaving them undefined. react-dom reads
+// `navigator.userAgent.indexOf(...)` at import time and crashed every suite that
+// imports @testing-library/react. Defining just serviceWorker on the real
+// navigator preserves userAgent et al.
+Object.defineProperty(window.navigator, 'serviceWorker', {
+  configurable: true,
   writable: true,
   value: {
-    ...window.navigator,
-    serviceWorker: {
-      register: jest.fn(() => Promise.resolve({
-        scope: '/',
-        installing: null,
-        waiting: null,
-        active: null,
-        addEventListener: jest.fn(),
-        update: jest.fn(() => Promise.resolve()),
-      })),
+    register: jest.fn(() => Promise.resolve({
+      scope: '/',
+      installing: null,
+      waiting: null,
+      active: null,
       addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
-      getRegistration: jest.fn(() => Promise.resolve(undefined)),
-      controller: null,
-    },
+      update: jest.fn(() => Promise.resolve()),
+    })),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    getRegistration: jest.fn(() => Promise.resolve(undefined)),
+    controller: null,
   },
 });
 


### PR DESCRIPTION
Root-causes and fixes the test failures that were unrelated to Phase 9. Before: 5 suites failing (3 tracked + 2 untracked WIP). After: **15 suites / 666 tests, all green**; type-check clean.

## Fixes
- **`src/setupTests.ts`** — the navigator mock spread `{ ...window.navigator }`, which drops prototype getters like `userAgent`. react-dom reads `navigator.userAgent.indexOf(...)` at import, so **every** suite importing `@testing-library/react` crashed at load. Now defines only `serviceWorker` on the real navigator.
- **`jest.config.js`** — `jsx: 'react'` (classic runtime) required `import React` in every component → "React is not defined" in render tests. Switched to `jsx: 'react-jsx'` (automatic runtime), matching Next's build.
- **`OptimizedImage.test.tsx`** — 8 tests asserted on the lazy-loaded `<img>` without simulating viewport entry (the component IntersectionObserver-gates it). Added an `act()`-wrapped `enterView()` helper; fixed the `next/image` mock to expose the boolean `fill` prop.
- **`stadiumDataIntegrity.test.ts`** — resolved `../../sections` (→ nonexistent `src/sections`) instead of `../sections`, scanning **0** files. Path fixed → 401 checks now run, which surfaced real duplicate section IDs.
- **6 orphan data files** — deduped duplicate section IDs (distinct sections that shared an `id`) in 0-importer stadium-name files.

The 2 remaining failures were **untracked WIP** test files (`report-inaccuracy`, `StadiumPageClient.integration`), parked in `_wip/` with the other untracked WIP — they don't affect CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)