### PR TITLE
Coverage audit tool + Angel Stadium research pass

### DIFF
--- a/app/stadium/[stadiumId]/StadiumPageSSR.tsx
+++ b/app/stadium/[stadiumId]/StadiumPageSSR.tsx
@@ -80,6 +80,9 @@ function getSeasonalPattern(month: number) {
 type ShadeTier = 'covered' | 'partial' | 'exposed';
 
 function shadeTierOf(section: StadiumSection): ShadeTier {
+  // Research-set full coverage wins (e.g. Angel Stadium Terrace — fully under
+  // the deck overhangs, not just back rows).
+  if (section.fullyCovered) return 'covered';
   // Explicit back-rows classification (researched venues: Yankees, White Sox) wins.
   if (section.partialCoverage) return 'partial';
   if (section.covered) {

--- a/scripts/auditAllVenueCoverage.ts
+++ b/scripts/auditAllVenueCoverage.ts
@@ -23,7 +23,7 @@ type DetailedSection = StadiumSection;
 
 // Excluded: hand-researched (yankees, whitesox) or reviewed-and-documented
 // (redsox — Fenway's Pavilion/field-box coverage is intentional, see Phase 3).
-const RESEARCHED = new Set(['yankees', 'whitesox', 'redsox']);
+const RESEARCHED = new Set(['yankees', 'whitesox', 'redsox', 'angels']);
 // HIGH-CONFIDENCE open-air names (full sun). Deliberately excludes "deck"
 // (Upper Deck / Top Deck are normal covered-back-row levels, not sun decks).
 const OPEN_AIR_NAME = /bleacher|pavilion|lawn|berm|porch|rooftop|patio|sun deck|home run porch|batter'?s eye/i;

--- a/scripts/auditAllVenueCoverage.ts
+++ b/scripts/auditAllVenueCoverage.ts
@@ -95,7 +95,7 @@ async function main() {
   }
 
   console.log(`\n${'='.repeat(60)}`);
-  console.log(`Audited OPEN-roof MLB venues (excluded researched: ${[...RESEARCHED].join(', ')}; retractable/fixed roofs skipped).`);
+  console.log(`Audited OPEN-roof MLB venues (excluded researched: ${Array.from(RESEARCHED).join(', ')}; retractable/fixed roofs skipped).`);
   console.log(`${venuesWithFlags} open-roof venue(s) with likely-wrong covered flags; ${totalFlags} suspicious open-air section(s).`);
   process.exit(venuesWithFlags ? 1 : 0);
 }

--- a/scripts/auditAllVenueCoverage.ts
+++ b/scripts/auditAllVenueCoverage.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env tsx
+/**
+ * Comprehensive MLB coverage audit (audit follow-up).
+ *
+ * For every MLB venue EXCEPT the two with hand-researched, section-by-section
+ * data (yankees, whitesox), report the coverage landscape and flag covered=true
+ * flags that are most likely wrong:
+ *   - open-air by NAME     (bleacher/pavilion/lawn/berm/porch/deck/rooftop/outfield)
+ *   - open-air by GEOMETRY (section center in the outfield arc, ~CF ± 55°) and
+ *                          NOT an indoor level (suite/club)
+ *   - whole-level 100% covered on an open-roof park (implausible)
+ *
+ * Run: npx tsx scripts/auditAllVenueCoverage.ts
+ */
+import { MLB_STADIUMS } from '../src/data/stadiums';
+// Use the SAME loader the stadium page uses (stadiumSections-split/*), not the
+// aggregator — the aggregator returns 65-section placeholder templates for most
+// venues, which is not what is rendered.
+import { getStadiumSectionsAsync } from '../src/data/getStadiumSections';
+import type { StadiumSection } from '../src/data/stadiumSectionTypes';
+
+type DetailedSection = StadiumSection;
+
+// Excluded: hand-researched (yankees, whitesox) or reviewed-and-documented
+// (redsox — Fenway's Pavilion/field-box coverage is intentional, see Phase 3).
+const RESEARCHED = new Set(['yankees', 'whitesox', 'redsox']);
+// HIGH-CONFIDENCE open-air names (full sun). Deliberately excludes "deck"
+// (Upper Deck / Top Deck are normal covered-back-row levels, not sun decks).
+const OPEN_AIR_NAME = /bleacher|pavilion|lawn|berm|porch|rooftop|patio|sun deck|home run porch|batter'?s eye/i;
+const INDOOR_NAME = /club|suite|lounge|indoor|cafe|café|bar|grill|restaurant|press/i;
+
+const pct = (n: number, d: number) => (d === 0 ? 0 : Math.round((n / d) * 100));
+
+// Section center as stadium-local angle (0=1B,90=CF,180=3B,270=HP). Outfield is
+// roughly CF ± 55° (35°..145° local).
+const isOutfieldGeom = (s: DetailedSection) => {
+  const c = (s.baseAngle + s.angleSpan / 2) % 360;
+  return c >= 35 && c <= 145;
+};
+
+async function main() {
+  let venuesWithFlags = 0;
+  let totalFlags = 0;
+
+  for (const stadium of MLB_STADIUMS) {
+    if (RESEARCHED.has(stadium.id)) continue;
+    let sections: DetailedSection[] = [];
+    try {
+      sections = await getStadiumSectionsAsync(stadium.id);
+    } catch {
+      continue;
+    }
+    if (!sections.length) continue;
+
+    // Retractable/fixed-roof venues are shaded everywhere when the roof is
+    // closed, so a high covered ratio is expected and not a bug. We only audit
+    // OPEN-roof parks, where covered=true must mean a real overhang.
+    const openRoof = stadium.roof === 'open';
+    if (!openRoof) continue;
+
+    const covered = sections.filter((s) => s.covered);
+    const byLevel: Record<string, { total: number; cov: number }> = {};
+    for (const s of sections) {
+      byLevel[s.level] ??= { total: 0, cov: 0 };
+      byLevel[s.level].total++;
+      if (s.covered) byLevel[s.level].cov++;
+    }
+
+    const flags: string[] = [];
+    for (const s of covered) {
+      if (INDOOR_NAME.test(s.name)) continue; // legitimately indoor
+      if (OPEN_AIR_NAME.test(s.name)) {
+        flags.push(`${s.name} [${s.level}] — open-air (full sun) marked covered`);
+      }
+    }
+    void isOutfieldGeom; // geometry flag retired — too noisy (upper decks legitimately overhang)
+    const covPct = pct(covered.length, sections.length);
+    const patternFlags: string[] = [];
+    if (covPct >= 50) patternFlags.push(`${covPct}% of an OPEN-roof park marked covered (implausibly high)`);
+    for (const [lvl, v] of Object.entries(byLevel)) {
+      if (v.total >= 6 && v.cov === v.total) patternFlags.push(`100% of ${lvl} (${v.total}) covered`);
+      if ((lvl === 'field') && v.cov > 0) patternFlags.push(`${v.cov} FIELD-level section(s) covered`);
+    }
+
+    if (flags.length || patternFlags.length) {
+      venuesWithFlags++;
+      totalFlags += flags.length;
+      const levelStr = Object.entries(byLevel).map(([l, v]) => `${l} ${v.cov}/${v.total}`).join(', ');
+      console.log(`\n${stadium.id} (${stadium.name}) — roof:${stadium.roof} · ${covered.length}/${sections.length} covered (${covPct}%)`);
+      console.log(`   levels: ${levelStr}`);
+      for (const lf of patternFlags) console.log(`   ⚠ ${lf}`);
+      for (const f of flags.slice(0, 12)) console.log(`   • ${f}`);
+      if (flags.length > 12) console.log(`   • …and ${flags.length - 12} more`);
+    }
+  }
+
+  console.log(`\n${'='.repeat(60)}`);
+  console.log(`Audited OPEN-roof MLB venues (excluded researched: ${[...RESEARCHED].join(', ')}; retractable/fixed roofs skipped).`);
+  console.log(`${venuesWithFlags} open-roof venue(s) with likely-wrong covered flags; ${totalFlags} suspicious open-air section(s).`);
+  process.exit(venuesWithFlags ? 1 : 0);
+}
+
+main();

--- a/src/data/stadiumSectionTypes.ts
+++ b/src/data/stadiumSectionTypes.ts
@@ -20,6 +20,10 @@ export interface StadiumSection {
   angleSpan: number; // How many degrees this section spans
   rows?: number; // Number of rows in section
   covered: boolean; // Whether section has overhead coverage
+  // Genuinely fully covered (all rows shaded), even at a bowl level where the
+  // generic 3-tier rule would otherwise assume back-rows-only. Set from research
+  // (e.g. Angel Stadium's Terrace level is fully under the deck overhangs).
+  fullyCovered?: boolean;
   partialCoverage?: boolean; // Whether section has partial coverage (e.g., back rows only)
   coveredRows?: string; // Which rows are covered (e.g., "M-Z" or "last 5 rows")
   price?: 'value' | 'moderate' | 'premium' | 'luxury';

--- a/src/data/stadiumSections-split/angels.ts
+++ b/src/data/stadiumSections-split/angels.ts
@@ -1,5 +1,16 @@
 import type { StadiumSection } from '../stadiumSectionTypes';
 
+// Angel Stadium coverage — researched 2026-07-17 from shadedseats.com,
+// RateYourSeats, and Shady-Seats shade guides. Orientation 65° (HP faces ENE);
+// the 3B side is the shaded side for afternoon games.
+//   • Terrace (200s / lower): fully under the deck overhangs — the best, most
+//     consistent shade in the park -> fullyCovered.
+//   • View (500s / upper): roof covers "row D and above" -> partial (back rows),
+//     front rows exposed.
+//   • Club (300s): under the upper-deck overhang -> covered.
+//   • Field (100s) + RF/LF Pavilion: open to the sky -> exposed. (The 3B-side
+//     field shade fans experience comes from ORIENTATION, computed by the sun
+//     engine, not from a structural overhang flag.)
 export const stadiumSections = {
     stadiumId: 'angels',
     sections: [
@@ -44,35 +55,35 @@ export const stadiumSections = {
       { id: '126', name: 'Field Level 126', level: 'field', baseAngle: 320, angleSpan: 10, covered: false, price: 'premium' },
       
       // Terrace Level - Behind Home Plate
-      { id: '201', name: 'Terrace Level 201', level: 'lower', baseAngle: 340, angleSpan: 10, covered: true, price: 'premium' },
-      { id: '202', name: 'Terrace Level 202', level: 'lower', baseAngle: 350, angleSpan: 10, covered: true, price: 'premium' },
-      { id: '203', name: 'Terrace Level 203', level: 'lower', baseAngle: 0, angleSpan: 10, covered: true, price: 'premium' },
-      { id: '204', name: 'Terrace Level 204', level: 'lower', baseAngle: 10, angleSpan: 10, covered: true, price: 'premium' },
-      { id: '205', name: 'Terrace Level 205', level: 'lower', baseAngle: 20, angleSpan: 10, covered: true, price: 'premium' },
+      { id: '201', name: 'Terrace Level 201', level: 'lower', baseAngle: 340, angleSpan: 10, covered: true, fullyCovered: true, price: 'premium' },
+      { id: '202', name: 'Terrace Level 202', level: 'lower', baseAngle: 350, angleSpan: 10, covered: true, fullyCovered: true, price: 'premium' },
+      { id: '203', name: 'Terrace Level 203', level: 'lower', baseAngle: 0, angleSpan: 10, covered: true, fullyCovered: true, price: 'premium' },
+      { id: '204', name: 'Terrace Level 204', level: 'lower', baseAngle: 10, angleSpan: 10, covered: true, fullyCovered: true, price: 'premium' },
+      { id: '205', name: 'Terrace Level 205', level: 'lower', baseAngle: 20, angleSpan: 10, covered: true, fullyCovered: true, price: 'premium' },
       
       // Terrace Level - First Base Side
-      { id: '206', name: 'Terrace Level 206', level: 'lower', baseAngle: 30, angleSpan: 10, covered: true, price: 'moderate' },
-      { id: '207', name: 'Terrace Level 207', level: 'lower', baseAngle: 40, angleSpan: 10, covered: true, price: 'moderate' },
-      { id: '208', name: 'Terrace Level 208', level: 'lower', baseAngle: 50, angleSpan: 10, covered: true, price: 'moderate' },
-      { id: '209', name: 'Terrace Level 209', level: 'lower', baseAngle: 60, angleSpan: 10, covered: true, price: 'moderate' },
-      { id: '210', name: 'Terrace Level 210', level: 'lower', baseAngle: 70, angleSpan: 10, covered: true, price: 'moderate' },
-      { id: '211', name: 'Terrace Level 211', level: 'lower', baseAngle: 80, angleSpan: 10, covered: true, price: 'moderate' },
-      { id: '212', name: 'Terrace Level 212', level: 'lower', baseAngle: 90, angleSpan: 10, covered: true, price: 'moderate' },
-      { id: '213', name: 'Terrace Level 213', level: 'lower', baseAngle: 100, angleSpan: 10, covered: true, price: 'value' },
-      { id: '214', name: 'Terrace Level 214', level: 'lower', baseAngle: 110, angleSpan: 10, covered: true, price: 'value' },
-      { id: '215', name: 'Terrace Level 215', level: 'lower', baseAngle: 120, angleSpan: 10, covered: true, price: 'value' },
+      { id: '206', name: 'Terrace Level 206', level: 'lower', baseAngle: 30, angleSpan: 10, covered: true, fullyCovered: true, price: 'moderate' },
+      { id: '207', name: 'Terrace Level 207', level: 'lower', baseAngle: 40, angleSpan: 10, covered: true, fullyCovered: true, price: 'moderate' },
+      { id: '208', name: 'Terrace Level 208', level: 'lower', baseAngle: 50, angleSpan: 10, covered: true, fullyCovered: true, price: 'moderate' },
+      { id: '209', name: 'Terrace Level 209', level: 'lower', baseAngle: 60, angleSpan: 10, covered: true, fullyCovered: true, price: 'moderate' },
+      { id: '210', name: 'Terrace Level 210', level: 'lower', baseAngle: 70, angleSpan: 10, covered: true, fullyCovered: true, price: 'moderate' },
+      { id: '211', name: 'Terrace Level 211', level: 'lower', baseAngle: 80, angleSpan: 10, covered: true, fullyCovered: true, price: 'moderate' },
+      { id: '212', name: 'Terrace Level 212', level: 'lower', baseAngle: 90, angleSpan: 10, covered: true, fullyCovered: true, price: 'moderate' },
+      { id: '213', name: 'Terrace Level 213', level: 'lower', baseAngle: 100, angleSpan: 10, covered: true, fullyCovered: true, price: 'value' },
+      { id: '214', name: 'Terrace Level 214', level: 'lower', baseAngle: 110, angleSpan: 10, covered: true, fullyCovered: true, price: 'value' },
+      { id: '215', name: 'Terrace Level 215', level: 'lower', baseAngle: 120, angleSpan: 10, covered: true, fullyCovered: true, price: 'value' },
       
       // Terrace Level - Third Base Side
-      { id: '219', name: 'Terrace Level 219', level: 'lower', baseAngle: 240, angleSpan: 10, covered: true, price: 'value' },
-      { id: '220', name: 'Terrace Level 220', level: 'lower', baseAngle: 250, angleSpan: 10, covered: true, price: 'value' },
-      { id: '221', name: 'Terrace Level 221', level: 'lower', baseAngle: 260, angleSpan: 10, covered: true, price: 'value' },
-      { id: '222', name: 'Terrace Level 222', level: 'lower', baseAngle: 270, angleSpan: 10, covered: true, price: 'moderate' },
-      { id: '223', name: 'Terrace Level 223', level: 'lower', baseAngle: 280, angleSpan: 10, covered: true, price: 'moderate' },
-      { id: '224', name: 'Terrace Level 224', level: 'lower', baseAngle: 290, angleSpan: 10, covered: true, price: 'moderate' },
-      { id: '225', name: 'Terrace Level 225', level: 'lower', baseAngle: 300, angleSpan: 10, covered: true, price: 'moderate' },
-      { id: '226', name: 'Terrace Level 226', level: 'lower', baseAngle: 310, angleSpan: 10, covered: true, price: 'moderate' },
-      { id: '227', name: 'Terrace Level 227', level: 'lower', baseAngle: 320, angleSpan: 10, covered: true, price: 'moderate' },
-      { id: '228', name: 'Terrace Level 228', level: 'lower', baseAngle: 330, angleSpan: 10, covered: true, price: 'moderate' },
+      { id: '219', name: 'Terrace Level 219', level: 'lower', baseAngle: 240, angleSpan: 10, covered: true, fullyCovered: true, price: 'value' },
+      { id: '220', name: 'Terrace Level 220', level: 'lower', baseAngle: 250, angleSpan: 10, covered: true, fullyCovered: true, price: 'value' },
+      { id: '221', name: 'Terrace Level 221', level: 'lower', baseAngle: 260, angleSpan: 10, covered: true, fullyCovered: true, price: 'value' },
+      { id: '222', name: 'Terrace Level 222', level: 'lower', baseAngle: 270, angleSpan: 10, covered: true, fullyCovered: true, price: 'moderate' },
+      { id: '223', name: 'Terrace Level 223', level: 'lower', baseAngle: 280, angleSpan: 10, covered: true, fullyCovered: true, price: 'moderate' },
+      { id: '224', name: 'Terrace Level 224', level: 'lower', baseAngle: 290, angleSpan: 10, covered: true, fullyCovered: true, price: 'moderate' },
+      { id: '225', name: 'Terrace Level 225', level: 'lower', baseAngle: 300, angleSpan: 10, covered: true, fullyCovered: true, price: 'moderate' },
+      { id: '226', name: 'Terrace Level 226', level: 'lower', baseAngle: 310, angleSpan: 10, covered: true, fullyCovered: true, price: 'moderate' },
+      { id: '227', name: 'Terrace Level 227', level: 'lower', baseAngle: 320, angleSpan: 10, covered: true, fullyCovered: true, price: 'moderate' },
+      { id: '228', name: 'Terrace Level 228', level: 'lower', baseAngle: 330, angleSpan: 10, covered: true, fullyCovered: true, price: 'moderate' },
       
       // Club Level (Premium sections)
       { id: 'C301', name: 'Club Level C301', level: 'club', baseAngle: 340, angleSpan: 10, covered: true, price: 'luxury' },
@@ -89,37 +100,37 @@ export const stadiumSections = {
       { id: 'C312', name: 'Club Level C312', level: 'club', baseAngle: 280, angleSpan: 10, covered: true, price: 'luxury' },
       
       // View Level - Behind Home Plate
-      { id: '401', name: 'View Level 401', level: 'upper', baseAngle: 340, angleSpan: 10, covered: true, price: 'moderate' },
-      { id: '402', name: 'View Level 402', level: 'upper', baseAngle: 350, angleSpan: 10, covered: true, price: 'moderate' },
-      { id: '403', name: 'View Level 403', level: 'upper', baseAngle: 0, angleSpan: 10, covered: true, price: 'moderate' },
-      { id: '404', name: 'View Level 404', level: 'upper', baseAngle: 10, angleSpan: 10, covered: true, price: 'moderate' },
-      { id: '405', name: 'View Level 405', level: 'upper', baseAngle: 20, angleSpan: 10, covered: true, price: 'moderate' },
+      { id: '401', name: 'View Level 401', level: 'upper', baseAngle: 340, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'moderate' },
+      { id: '402', name: 'View Level 402', level: 'upper', baseAngle: 350, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'moderate' },
+      { id: '403', name: 'View Level 403', level: 'upper', baseAngle: 0, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'moderate' },
+      { id: '404', name: 'View Level 404', level: 'upper', baseAngle: 10, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'moderate' },
+      { id: '405', name: 'View Level 405', level: 'upper', baseAngle: 20, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'moderate' },
       
       // View Level - First Base Side
-      { id: '406', name: 'View Level 406', level: 'upper', baseAngle: 30, angleSpan: 10, covered: true, price: 'value' },
-      { id: '407', name: 'View Level 407', level: 'upper', baseAngle: 40, angleSpan: 10, covered: true, price: 'value' },
-      { id: '408', name: 'View Level 408', level: 'upper', baseAngle: 50, angleSpan: 10, covered: true, price: 'value' },
-      { id: '409', name: 'View Level 409', level: 'upper', baseAngle: 60, angleSpan: 10, covered: true, price: 'value' },
-      { id: '410', name: 'View Level 410', level: 'upper', baseAngle: 70, angleSpan: 10, covered: true, price: 'value' },
-      { id: '411', name: 'View Level 411', level: 'upper', baseAngle: 80, angleSpan: 10, covered: true, price: 'value' },
-      { id: '412', name: 'View Level 412', level: 'upper', baseAngle: 90, angleSpan: 10, covered: true, price: 'value' },
-      { id: '413', name: 'View Level 413', level: 'upper', baseAngle: 100, angleSpan: 10, covered: true, price: 'value' },
-      { id: '414', name: 'View Level 414', level: 'upper', baseAngle: 110, angleSpan: 10, covered: true, price: 'value' },
-      { id: '415', name: 'View Level 415', level: 'upper', baseAngle: 120, angleSpan: 10, covered: true, price: 'value' },
-      { id: '416', name: 'View Level 416', level: 'upper', baseAngle: 130, angleSpan: 10, covered: true, price: 'value' },
-      { id: '417', name: 'View Level 417', level: 'upper', baseAngle: 140, angleSpan: 10, covered: true, price: 'value' },
+      { id: '406', name: 'View Level 406', level: 'upper', baseAngle: 30, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'value' },
+      { id: '407', name: 'View Level 407', level: 'upper', baseAngle: 40, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'value' },
+      { id: '408', name: 'View Level 408', level: 'upper', baseAngle: 50, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'value' },
+      { id: '409', name: 'View Level 409', level: 'upper', baseAngle: 60, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'value' },
+      { id: '410', name: 'View Level 410', level: 'upper', baseAngle: 70, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'value' },
+      { id: '411', name: 'View Level 411', level: 'upper', baseAngle: 80, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'value' },
+      { id: '412', name: 'View Level 412', level: 'upper', baseAngle: 90, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'value' },
+      { id: '413', name: 'View Level 413', level: 'upper', baseAngle: 100, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'value' },
+      { id: '414', name: 'View Level 414', level: 'upper', baseAngle: 110, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'value' },
+      { id: '415', name: 'View Level 415', level: 'upper', baseAngle: 120, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'value' },
+      { id: '416', name: 'View Level 416', level: 'upper', baseAngle: 130, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'value' },
+      { id: '417', name: 'View Level 417', level: 'upper', baseAngle: 140, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'value' },
       
       // View Level - Third Base Side
-      { id: '421', name: 'View Level 421', level: 'upper', baseAngle: 220, angleSpan: 10, covered: true, price: 'value' },
-      { id: '422', name: 'View Level 422', level: 'upper', baseAngle: 230, angleSpan: 10, covered: true, price: 'value' },
-      { id: '423', name: 'View Level 423', level: 'upper', baseAngle: 240, angleSpan: 10, covered: true, price: 'value' },
-      { id: '424', name: 'View Level 424', level: 'upper', baseAngle: 250, angleSpan: 10, covered: true, price: 'value' },
-      { id: '425', name: 'View Level 425', level: 'upper', baseAngle: 260, angleSpan: 10, covered: true, price: 'value' },
-      { id: '426', name: 'View Level 426', level: 'upper', baseAngle: 270, angleSpan: 10, covered: true, price: 'value' },
-      { id: '427', name: 'View Level 427', level: 'upper', baseAngle: 280, angleSpan: 10, covered: true, price: 'value' },
-      { id: '428', name: 'View Level 428', level: 'upper', baseAngle: 290, angleSpan: 10, covered: true, price: 'value' },
-      { id: '429', name: 'View Level 429', level: 'upper', baseAngle: 300, angleSpan: 10, covered: true, price: 'value' },
-      { id: '430', name: 'View Level 430', level: 'upper', baseAngle: 310, angleSpan: 10, covered: true, price: 'value' },
+      { id: '421', name: 'View Level 421', level: 'upper', baseAngle: 220, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'value' },
+      { id: '422', name: 'View Level 422', level: 'upper', baseAngle: 230, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'value' },
+      { id: '423', name: 'View Level 423', level: 'upper', baseAngle: 240, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'value' },
+      { id: '424', name: 'View Level 424', level: 'upper', baseAngle: 250, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'value' },
+      { id: '425', name: 'View Level 425', level: 'upper', baseAngle: 260, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'value' },
+      { id: '426', name: 'View Level 426', level: 'upper', baseAngle: 270, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'value' },
+      { id: '427', name: 'View Level 427', level: 'upper', baseAngle: 280, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'value' },
+      { id: '428', name: 'View Level 428', level: 'upper', baseAngle: 290, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'value' },
+      { id: '429', name: 'View Level 429', level: 'upper', baseAngle: 300, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'value' },
+      { id: '430', name: 'View Level 430', level: 'upper', baseAngle: 310, angleSpan: 10, covered: true, coveredRows: 'row D and above', price: 'value' },
       
       // Right Field Pavilion
       { id: '230', name: 'Right Field Pavilion 230', level: 'field', baseAngle: 160, angleSpan: 20, covered: false, price: 'value' },


### PR DESCRIPTION
Two follow-ups, verified locally (build clean, 611/611 tests):

1. **Comprehensive MLB coverage audit** (`scripts/auditAllVenueCoverage.ts`) — audits the ACTUAL rendered data (`stadiumSections-split/*`), not the aggregator (which returns 65-section placeholder templates for 27/30 venues). Skips researched + retractable/dome venues; flags open-air-named covered sections and implausible coverage on open-roof parks.
2. **Angel Stadium research pass** — the audit's "over-covered" flag was a false alarm (Angel Stadium genuinely has extensive tiered overhangs). Real fix was the opposite: the Terrace (best shade) was under-stated as "partial". Added `StadiumSection.fullyCovered`; Terrace → fully Covered, View → "row D and above", Club covered, Field exposed. Scoped to Angels only.

Verified in build: angels Terrace "✓ Covered", View "◐ row D and above", Field "— Exposed"; no other venue changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)