### PR TITLE
feat: mobile section cards, 2026 venue names, blog freshness + recrawl prep

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -105,7 +105,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
     description: post.description,
     image: [postImage],
     datePublished: post.dateISO,
-    dateModified: post.dateISO,
+    dateModified: post.dateModifiedISO || post.dateISO,
     author: {
       '@type': 'Organization',
       name: post.author || 'The Shadium',
@@ -153,11 +153,14 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
               <Link href={`/blog/category/${post.category}`} className="post-category">
                 {post.category.replace(/-/g, ' ')}
               </Link>
-              <span className="post-date">{new Date(post.date).toLocaleDateString('en-US', { 
-                year: 'numeric', 
-                month: 'long', 
-                day: 'numeric' 
+              <span className="post-date">{new Date(post.date).toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric'
               })}</span>
+              {post.dateModified && (
+                <span className="post-updated">Updated {post.dateModified}</span>
+              )}
               <span className="post-reading-time">{post.readingTime}</span>
             </div>
             

--- a/app/blog/blog-post.css
+++ b/app/blog/blog-post.css
@@ -45,6 +45,11 @@
   flex-wrap: wrap;
 }
 
+.post-updated {
+  font-weight: 600;
+  color: var(--accent-700);
+}
+
 .post-category {
   color: var(--accent-600);
   text-decoration: none;

--- a/app/stadium/[stadiumId]/StadiumPageSSR.module.css
+++ b/app/stadium/[stadiumId]/StadiumPageSSR.module.css
@@ -340,6 +340,86 @@
   font-size: 1rem;
 }
 
+/* Desktop table vs mobile cards toggle for the All-Sections analysis. */
+.desktopOnly { display: block; }
+.mobileOnly { display: none; }
+
+/* Mobile card view: collapsible groups by seating level. */
+.levelGroup {
+  margin-top: 1rem;
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.levelSummary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  min-height: 44px; /* accessible tap target */
+  padding: 0.75rem 1rem;
+  font-size: 1.0625rem;
+  font-weight: 600;
+  color: #1a237e;
+  background: #f5f5f5;
+  cursor: pointer;
+  list-style: none;
+}
+.levelSummary::-webkit-details-marker { display: none; }
+.levelSummary::after {
+  content: '▸';
+  margin-left: auto;
+  font-size: 1rem;
+  color: #666;
+  transition: transform 0.15s ease;
+}
+.levelGroup[open] .levelSummary::after { transform: rotate(90deg); }
+
+.levelCount {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #666;
+}
+
+.sectionCards {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sectionCard {
+  padding: 0.875rem 1rem;
+  border-top: 1px solid #eee;
+}
+
+.sectionCardHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.sectionCardName {
+  font-size: 1rem; /* >= 16px body text */
+  font-weight: 600;
+  color: #222;
+}
+
+.sectionCardMeta {
+  margin-top: 0.25rem;
+  font-size: 1rem;
+  color: #444;
+}
+
+.sectionCardNotes {
+  margin: 0.35rem 0 0;
+  font-size: 1rem;
+  line-height: 1.45;
+  color: #555;
+}
+
 .rating5 { color: #4caf50; }
 .rating4 { color: #8bc34a; }
 .rating3 { color: #ffc107; }
@@ -440,10 +520,14 @@
 }
 
 @media (max-width: 768px) {
+  /* Swap the wide All-Sections table for the collapsible card view. */
+  .desktopOnly { display: none; }
+  .mobileOnly { display: block; }
+
   .section {
     padding: 20px 0; /* Reduced mobile padding */
   }
-  
+
   .stadiumHero {
     padding: 20px 0; /* Reduced mobile padding */
   }

--- a/app/stadium/[stadiumId]/StadiumPageSSR.tsx
+++ b/app/stadium/[stadiumId]/StadiumPageSSR.tsx
@@ -96,6 +96,33 @@ function shadeTierOf(section: StadiumSection): ShadeTier {
   return 'exposed';
 }
 
+// Seating-level display order + labels for the mobile "All Sections" card view.
+const LEVEL_ORDER: Array<StadiumSection['level']> = ['field', 'lower', 'club', 'upper', 'suite'];
+const LEVEL_LABEL: Record<StadiumSection['level'], string> = {
+  field: 'Field Level',
+  lower: 'Lower Level',
+  club: 'Club Level',
+  upper: 'Upper Level',
+  suite: 'Suites',
+};
+
+// Shared per-section display data so the desktop table and the mobile cards
+// stay identical (single source of the tier → rating/coverage/notes mapping).
+function sectionRowData(section: StadiumSection) {
+  const tier = shadeTierOf(section);
+  const shadeRating = tier === 'covered' ? 5 : tier === 'partial' ? 3 : section.level === 'upper' ? 2 : 1;
+  const coverageLabel = tier === 'covered' ? '✓ Covered' :
+    tier === 'partial' ? `◐ ${section.coveredRows || 'back rows'}` : '— Exposed';
+  const bestTime = tier === 'covered' ? 'All day' :
+    tier === 'partial' ? 'Day games (back rows)' : 'Evening games';
+  const notes = tier === 'covered' ? 'Guaranteed shade — fully covered' :
+    tier === 'partial' ? 'Overhang shade in the back rows only; front rows exposed' :
+    section.level === 'upper' ? 'Exposed — some relief from self-shading late in the game' :
+    'Exposed — little to no shade';
+  const stars = '★'.repeat(shadeRating) + '☆'.repeat(5 - shadeRating);
+  return { shadeRating, coverageLabel, bestTime, notes, stars };
+}
+
 export default function StadiumPageSSR({ stadium, sections, amenities, guide }: StadiumPageSSRProps) {
 
   // Pre-calculate shade data for common scenarios
@@ -293,7 +320,9 @@ export default function StadiumPageSSR({ stadium, sections, amenities, guide }: 
       <section className={styles.section}>
         <div className={styles.container}>
           <h2>All Sections Shade Analysis</h2>
-          <div className={styles.sectionsTableWrapper}>
+
+          {/* Desktop: full table (hidden < 768px) */}
+          <div className={`${styles.sectionsTableWrapper} ${styles.desktopOnly}`}>
             <table className={styles.sectionsTable}>
               <thead>
                 <tr>
@@ -307,30 +336,14 @@ export default function StadiumPageSSR({ stadium, sections, amenities, guide }: 
               </thead>
               <tbody>
                 {sections.map(section => {
-                  const tier = shadeTierOf(section);
-                  const shadeRating = tier === 'covered' ? 5 :
-                                     tier === 'partial' ? 3 :
-                                     section.level === 'upper' ? 2 : 1;
-                  const coverageLabel = tier === 'covered' ? '✓ Covered' :
-                                        tier === 'partial' ? `◐ ${section.coveredRows || 'back rows'}` :
-                                        '— Exposed';
-                  const bestTime = tier === 'covered' ? 'All day' :
-                                  tier === 'partial' ? 'Day games (back rows)' :
-                                  'Evening games';
-                  const notes = tier === 'covered' ? 'Guaranteed shade — fully covered' :
-                                tier === 'partial' ? 'Overhang shade in the back rows only; front rows exposed' :
-                                section.level === 'upper' ? 'Exposed — some relief from self-shading late in the game' :
-                                'Exposed — little to no shade';
-
+                  const { shadeRating, coverageLabel, bestTime, notes, stars } = sectionRowData(section);
                   return (
                     <tr key={section.id}>
                       <td>{section.name}</td>
                       <td>{section.level}</td>
                       <td>{coverageLabel}</td>
                       <td>
-                        <span className={`${styles.rating} ${styles[`rating${shadeRating}`]}`}>
-                          {'★'.repeat(shadeRating)}{'☆'.repeat(5 - shadeRating)}
-                        </span>
+                        <span className={`${styles.rating} ${styles[`rating${shadeRating}`]}`}>{stars}</span>
                       </td>
                       <td>{bestTime}</td>
                       <td>{notes}</td>
@@ -339,6 +352,38 @@ export default function StadiumPageSSR({ stadium, sections, amenities, guide }: 
                 })}
               </tbody>
             </table>
+          </div>
+
+          {/* Mobile: collapsible cards grouped by seating level (shown < 768px).
+              Uses native <details> so it works without JS and stays crawlable. */}
+          <div className={styles.mobileOnly}>
+            {LEVEL_ORDER.map(level => {
+              const levelSections = sections.filter(s => s.level === level);
+              if (!levelSections.length) return null;
+              return (
+                <details key={level} className={styles.levelGroup} open>
+                  <summary className={styles.levelSummary}>
+                    <span>{LEVEL_LABEL[level]}</span>
+                    <span className={styles.levelCount}>{levelSections.length} sections</span>
+                  </summary>
+                  <ul className={styles.sectionCards}>
+                    {levelSections.map(section => {
+                      const { shadeRating, coverageLabel, bestTime, notes, stars } = sectionRowData(section);
+                      return (
+                        <li key={section.id} className={styles.sectionCard}>
+                          <div className={styles.sectionCardHead}>
+                            <span className={styles.sectionCardName}>{section.name}</span>
+                            <span className={`${styles.rating} ${styles[`rating${shadeRating}`]}`}>{stars}</span>
+                          </div>
+                          <div className={styles.sectionCardMeta}>{coverageLabel} · {bestTime}</div>
+                          <p className={styles.sectionCardNotes}>{notes}</p>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </details>
+              );
+            })}
           </div>
         </div>
       </section>

--- a/content/blog/shaded-seats-american-family-field.mdx
+++ b/content/blog/shaded-seats-american-family-field.mdx
@@ -2,6 +2,7 @@
 title: "Shaded Seats at American Family Field: Complete Guide"
 description: "Find the best shaded seats at American Family Field in Milwaukee. Learn how the retractable roof and northwest-facing orientation affect shade for Brewers day games."
 date: "2025-09-15"
+dateModified: "2026-07-17"
 author: "The Shadium Team"
 category: "stadium-guides"
 tags: ["american-family-field", "milwaukee-brewers", "mlb", "shaded-seats", "day-games", "milwaukee"]

--- a/content/blog/shaded-seats-angel-stadium.mdx
+++ b/content/blog/shaded-seats-angel-stadium.mdx
@@ -2,6 +2,7 @@
 title: "Shaded Seats at Angel Stadium: Complete Guide"
 description: "Find the best shaded seats at Angel Stadium in Anaheim. Learn which sections offer the most shade during Los Angeles Angels day games."
 date: "2025-09-15"
+dateModified: "2026-07-17"
 author: "The Shadium Team"
 category: "stadium-guides"
 tags: ["angel-stadium", "los-angeles-angels", "mlb", "shaded-seats", "day-games", "anaheim"]

--- a/content/blog/shaded-seats-busch-stadium.mdx
+++ b/content/blog/shaded-seats-busch-stadium.mdx
@@ -2,6 +2,7 @@
 title: "Shaded Seats at Busch Stadium: Complete Guide"
 description: "Find the best shaded seats at Busch Stadium in St. Louis. Learn how the stadium's east-northeast orientation maximizes afternoon shade on the first base side."
 date: "2025-09-15"
+dateModified: "2026-07-17"
 author: "The Shadium Team"
 category: "stadium-guides"
 tags: ["busch-stadium", "st-louis-cardinals", "mlb", "shaded-seats", "day-games", "st-louis"]

--- a/content/blog/shaded-seats-camden-yards.mdx
+++ b/content/blog/shaded-seats-camden-yards.mdx
@@ -2,6 +2,7 @@
 title: "Shaded Seats at Oriole Park at Camden Yards: Complete Guide"
 description: "Find the best shaded seats at Oriole Park at Camden Yards. Learn which sections offer the most shade during Baltimore Orioles day games."
 date: "2025-09-15"
+dateModified: "2026-07-17"
 author: "The Shadium Team"
 category: "stadium-guides"
 tags: ["camden-yards", "baltimore-orioles", "mlb", "shaded-seats", "day-games", "baltimore"]

--- a/content/blog/shaded-seats-chase-field.mdx
+++ b/content/blog/shaded-seats-chase-field.mdx
@@ -2,6 +2,7 @@
 title: "Shaded Seats at Chase Field: Complete Guide"
 description: "Find the best shaded seats at Chase Field in Phoenix. Learn how the retractable roof handles Arizona heat and discover shade options when the roof is open."
 date: "2025-09-15"
+dateModified: "2026-07-17"
 author: "The Shadium Team"
 category: "stadium-guides"
 tags: ["chase-field", "arizona-diamondbacks", "mlb", "shaded-seats", "day-games", "phoenix"]

--- a/content/blog/shaded-seats-citizens-bank-park.mdx
+++ b/content/blog/shaded-seats-citizens-bank-park.mdx
@@ -2,6 +2,7 @@
 title: "Shaded Seats at Citizens Bank Park: Complete Guide"
 description: "Discover the best shaded seats at Citizens Bank Park in Philadelphia. Learn where to sit to escape afternoon sun at the Phillies' modern ballpark."
 date: "2025-09-15"
+dateModified: "2026-07-17"
 author: "The Shadium Team"
 category: "stadium-guides"
 tags: ["citizens-bank-park", "philadelphia-phillies", "mlb", "shaded-seats", "day-games", "philadelphia"]

--- a/content/blog/shaded-seats-coors-field.mdx
+++ b/content/blog/shaded-seats-coors-field.mdx
@@ -2,6 +2,7 @@
 title: "Shaded Seats at Coors Field: Complete Guide"
 description: "Find the best shaded seats at Coors Field in Denver. Learn why high altitude requires extra sun protection and discover why seats behind home plate offer the best shade for Rockies day games."
 date: "2025-09-15"
+dateModified: "2026-07-17"
 author: "The Shadium Team"
 category: "stadium-guides"
 tags: ["coors-field", "colorado-rockies", "mlb", "shaded-seats", "day-games", "denver"]

--- a/content/blog/shaded-seats-great-american-ball-park.mdx
+++ b/content/blog/shaded-seats-great-american-ball-park.mdx
@@ -2,6 +2,7 @@
 title: "Shaded Seats at Great American Ball Park: Complete Guide"
 description: "Discover the best shaded seats at Great American Ball Park in Cincinnati. Find afternoon shade options for Reds day games at this Ohio River ballpark."
 date: "2025-09-15"
+dateModified: "2026-07-17"
 author: "The Shadium Team"
 category: "stadium-guides"
 tags: ["great-american-ball-park", "cincinnati-reds", "mlb", "shaded-seats", "day-games", "cincinnati"]

--- a/content/blog/shaded-seats-guaranteed-rate-field.mdx
+++ b/content/blog/shaded-seats-guaranteed-rate-field.mdx
@@ -1,59 +1,60 @@
 ---
-title: "Shaded Seats at Guaranteed Rate Field: Complete Guide"
-description: "Find the best shaded seats at Guaranteed Rate Field. Learn which sections stay shaded during Chicago White Sox day games on the South Side."
+title: "Shaded Seats at Rate Field: Complete Guide"
+description: "Find the best shaded seats at Rate Field. Learn which sections stay shaded during Chicago White Sox day games on the South Side."
 date: "2025-09-15"
+dateModified: "2026-07-17"
 author: "The Shadium Team"
 category: "stadium-guides"
 tags: ["guaranteed-rate-field", "chicago-white-sox", "mlb", "shaded-seats", "day-games", "chicago"]
-excerpt: "Guaranteed Rate Field on Chicago's South Side has an east-southeast orientation that creates some of the most consistently shaded third-base-side seating in the American League. Here's where to sit for the most comfortable White Sox day game experience."
+excerpt: "Rate Field on Chicago's South Side has an east-southeast orientation that creates some of the most consistently shaded first-base-side seating in the American League. Here's where to sit for the most comfortable White Sox day game experience."
 ---
 
-## Why Shade Matters at Guaranteed Rate Field
+## Why Shade Matters at Rate Field
 
-Chicago summers swing from cool lake breezes to brutal heat waves, often within the same week. Guaranteed Rate Field is an outdoor, open-air stadium with no roof and limited natural windbreaks. When the city heats up and the Sox are playing a summer afternoon game, your seat location makes a real difference.
+Chicago summers swing from cool lake breezes to brutal heat waves, often within the same week. Rate Field is an outdoor, open-air stadium with no roof and limited natural windbreaks. When the city heats up and the Sox are playing a summer afternoon game, your seat location makes a real difference.
 
-Guaranteed Rate Field — or "The Rate" as locals call it — opened in 1991 as Comiskey Park and has been home to White Sox baseball for over three decades. Its South Side location, industrial-scale architecture, and the upper deck overhangs are the key structural factors that determine shade patterns across the stadium.
+Rate Field — or "The Rate" as locals call it, formerly known as Guaranteed Rate Field — opened in 1991 as Comiskey Park and has been home to White Sox baseball for over three decades. Its South Side location, industrial-scale architecture, and the upper deck overhangs are the key structural factors that determine shade patterns across the stadium.
 
-## Guaranteed Rate Field Sun and Shade Overview
+## Rate Field Sun and Shade Overview
 
-Guaranteed Rate Field has an east-southeast-facing orientation (120°), meaning home plate faces west-northwest and center field points toward the east-southeast. This orientation is more east-facing than most MLB parks, and it creates favorable shade conditions on the third base side.
+Rate Field has an east-southeast-facing orientation (120°), meaning home plate faces west-northwest and center field points toward the east-southeast. This orientation is more east-facing than most MLB parks, and it creates favorable shade conditions on the first base side.
 
-Because the stadium faces ESE at 120°, the third base side of the park faces roughly north-northeast. The sun in Chicago arcs through the southern sky, reaching its highest point due south and tracking southwest in the afternoon. Third base sections, facing NNE, are oriented almost exactly away from that arc — which means they spend much of the afternoon in the shadow of the upper deck and stadium structure.
+Because the stadium faces ESE at 120°, the first base side of the park faces roughly north-northeast. The sun in Chicago arcs through the southern sky, reaching its highest point due south and tracking southwest in the afternoon. First base sections, facing NNE, are oriented almost exactly away from that arc — which means they spend much of the afternoon in the shadow of the upper deck and stadium structure.
 
-This makes the third base side of Guaranteed Rate Field one of the more consistently shaded seating areas among American League parks.
+This makes the first base side of Rate Field one of the more consistently shaded seating areas among American League parks.
 
 ## Best Shaded Sections
 
 ### Afternoon Day Games (2:00–4:00 PM)
 
-The third base side is your primary shade destination for afternoon games. The upper deck at The Rate is a prominent structure, and the overhang it creates over the lower deck on the third base line provides solid shade coverage from roughly the second inning onward during a 2:00-4:00 PM start.
+The first base side is your primary shade destination for afternoon games. The upper deck at The Rate is a prominent structure, and the overhang it creates over the lower deck on the first base line provides solid shade coverage from roughly the second inning onward during a 2:00-4:00 PM start.
 
-Sections in the lower deck along the third base line, directly beneath the upper deck overhang, receive the earliest and most complete shade protection. The upper deck third base sections are also shaded from the south/southwest sun since they face north-northeast, but they're exposed to open sky above (no roof), so you lose the overhead shading you get in the lower deck.
+Sections in the lower deck along the first base line, directly beneath the upper deck overhang, receive the earliest and most complete shade protection. The upper deck first base sections are also shaded from the south/southwest sun since they face north-northeast, but they're exposed to open sky above (no roof), so you lose the overhead shading you get in the lower deck.
 
 The area behind home plate is another reliable shade zone for afternoon games. The upper deck extends around the infield, and sections in the lower deck directly below it receive coverage from both the structure above and the position of the afternoon sun.
 
 ### Morning and Early Afternoon Games
 
-For noon or 1:00 PM starts, the sun is still working from the east/southeast. Because the stadium faces ESE, the sun in the morning is somewhat aligned with the CF direction, which means it shines more directly toward home plate in the early innings. The first base side may have slightly more shade in the first few innings, but as the sun climbs to the south by mid-game, the third base side takes over as the shade side.
+For noon or 1:00 PM starts, the sun is still working from the east/southeast. Because the stadium faces ESE, the sun in the morning is somewhat aligned with the CF direction, which means it shines more directly toward home plate in the early innings. The third base side may have slightly more shade in the first few innings, but as the sun climbs to the south by mid-game, the first base side takes over as the shade side.
 
-## Seasonal Guide at Guaranteed Rate Field
+## Seasonal Guide at Rate Field
 
-**Spring (April–May):** Chicago spring weather is unpredictable — sometimes breezy and cold, sometimes warmer than expected. When the sun is out, the third base side offers the best shade. April games often require layers regardless of seat location.
+**Spring (April–May):** Chicago spring weather is unpredictable — sometimes breezy and cold, sometimes warmer than expected. When the sun is out, the first base side offers the best shade. April games often require layers regardless of seat location.
 
-**Summer (June–August):** This is when shade matters most. Chicago heat waves can push temperatures into the 90s, and the South Side doesn't get the lakefront breezes that Wrigley Field sometimes benefits from. Third base lower deck sections beneath the upper deck overhang are the most comfortable choice for summer day games.
+**Summer (June–August):** This is when shade matters most. Chicago heat waves can push temperatures into the 90s, and the South Side doesn't get the lakefront breezes that Wrigley Field sometimes benefits from. First base lower deck sections beneath the upper deck overhang are the most comfortable choice for summer day games.
 
-**Fall (September–October):** The sun drops lower in the sky as the season winds down, which actually increases the reach of shadows from the upper deck. Third base sections come into shade earlier in the game during fall starts. Temperatures drop significantly, making late-season games comfortable in almost any section.
+**Fall (September–October):** The sun drops lower in the sky as the season winds down, which actually increases the reach of shadows from the upper deck. First base sections come into shade earlier in the game during fall starts. Temperatures drop significantly, making late-season games comfortable in almost any section.
 
 ## The Upper Deck at The Rate
 
-The upper deck at Guaranteed Rate Field is a defining architectural feature. It wraps around the infield and rises steeply, which is characteristic of the early-90s stadium design era. This steep upper deck creates a pronounced overhang that shades the lower deck more effectively than stadiums with more gradual seating gradients.
+The upper deck at Rate Field is a defining architectural feature. It wraps around the infield and rises steeply, which is characteristic of the early-90s stadium design era. This steep upper deck creates a pronounced overhang that shades the lower deck more effectively than stadiums with more gradual seating gradients.
 
-If shade is your top priority, the lower deck sections directly beneath the upper deck on the third base side offer the best combination of shade and sight lines.
+If shade is your top priority, the lower deck sections directly beneath the upper deck on the first base side offer the best combination of shade and sight lines.
 
-## Pro Tips for Staying Cool at Guaranteed Rate Field
+## Pro Tips for Staying Cool at Rate Field
 
 Wear light-colored, breathable clothing to any summer day game. The South Side's urban landscape absorbs heat differently than parks in more open areas, and the concrete and asphalt around the stadium can make it feel warmer before you even get inside.
 
 The stadium has concessions selling cold beverages throughout the concourse, and water fountains are available at multiple points. Bring a small water bottle to supplement.
 
-Use The Shadium for real-time shade calculations at Guaranteed Rate Field before your game. Enter your game date and time and the tool shows you exactly which sections will be shaded — so you can lock in the right seats from the start.
+Use The Shadium for real-time shade calculations at Rate Field before your game. Enter your game date and time and the tool shows you exactly which sections will be shaded — so you can lock in the right seats from the start.

--- a/content/blog/shaded-seats-kauffman-stadium.mdx
+++ b/content/blog/shaded-seats-kauffman-stadium.mdx
@@ -2,6 +2,7 @@
 title: "Shaded Seats at Kauffman Stadium: Complete Guide"
 description: "Find the best shaded seats at Kauffman Stadium in Kansas City. Discover afternoon shade options and get tips for Royals day games at this iconic ballpark."
 date: "2025-09-15"
+dateModified: "2026-07-17"
 author: "The Shadium Team"
 category: "stadium-guides"
 tags: ["kauffman-stadium", "kansas-city-royals", "mlb", "shaded-seats", "day-games", "kansas-city"]

--- a/content/blog/shaded-seats-loanDepot-park.mdx
+++ b/content/blog/shaded-seats-loanDepot-park.mdx
@@ -2,6 +2,7 @@
 title: "Shaded Seats at loanDepot park: Complete Guide"
 description: "Find the best shaded seats at loanDepot park. With a retractable roof, the Miami Marlins' stadium offers climate-controlled comfort for most day games."
 date: "2025-09-15"
+dateModified: "2026-07-17"
 author: "The Shadium Team"
 category: "stadium-guides"
 tags: ["loanDepot-park", "miami-marlins", "mlb", "shaded-seats", "day-games", "miami"]

--- a/content/blog/shaded-seats-minute-maid-park.mdx
+++ b/content/blog/shaded-seats-minute-maid-park.mdx
@@ -2,6 +2,7 @@
 title: "Shaded Seats at Minute Maid Park: Complete Guide"
 description: "Discover shaded seats at Minute Maid Park in Houston. Learn about the retractable roof advantage and shade patterns when playing with the roof open."
 date: "2025-09-15"
+dateModified: "2026-07-17"
 author: "The Shadium Team"
 category: "stadium-guides"
 tags: ["minute-maid-park", "houston-astros", "mlb", "shaded-seats", "day-games", "houston"]

--- a/content/blog/shaded-seats-nationals-park.mdx
+++ b/content/blog/shaded-seats-nationals-park.mdx
@@ -2,6 +2,7 @@
 title: "Shaded Seats at Nationals Park: Complete Guide"
 description: "Find the best shaded seats at Nationals Park. Learn which sections offer the most shade during Washington Nationals day games in DC's summer heat."
 date: "2025-09-15"
+dateModified: "2026-07-17"
 author: "The Shadium Team"
 category: "stadium-guides"
 tags: ["nationals-park", "washington-nationals", "mlb", "shaded-seats", "day-games", "washington-dc"]

--- a/content/blog/shaded-seats-petco-park.mdx
+++ b/content/blog/shaded-seats-petco-park.mdx
@@ -2,6 +2,7 @@
 title: "Shaded Seats at Petco Park: Complete Guide"
 description: "Find the best shaded seats at Petco Park in San Diego. Learn how the historic Western Metal Supply Building creates unique shade patterns for Padres fans."
 date: "2025-09-15"
+dateModified: "2026-07-17"
 author: "The Shadium Team"
 category: "stadium-guides"
 tags: ["petco-park", "san-diego-padres", "mlb", "shaded-seats", "day-games", "san-diego"]

--- a/content/blog/shaded-seats-pnc-park.mdx
+++ b/content/blog/shaded-seats-pnc-park.mdx
@@ -2,6 +2,7 @@
 title: "Shaded Seats at PNC Park: Complete Guide"
 description: "Discover the best shaded seats at PNC Park in Pittsburgh. Find afternoon shade options and learn sun patterns for Pirates day games at this iconic riverfront ballpark."
 date: "2025-09-15"
+dateModified: "2026-07-17"
 author: "The Shadium Team"
 category: "stadium-guides"
 tags: ["pnc-park", "pittsburgh-pirates", "mlb", "shaded-seats", "day-games", "pittsburgh"]

--- a/content/blog/shaded-seats-progressive-field.mdx
+++ b/content/blog/shaded-seats-progressive-field.mdx
@@ -2,6 +2,7 @@
 title: "Shaded Seats at Progressive Field: Complete Guide"
 description: "Discover the best shaded seats at Progressive Field in Cleveland. Learn the due-north orientation advantages and find cool spots for Guardians day games in downtown Ohio."
 date: "2025-09-15"
+dateModified: "2026-07-17"
 author: "The Shadium Team"
 category: "stadium-guides"
 tags: ["progressive-field", "cleveland-guardians", "mlb", "shaded-seats", "day-games", "cleveland"]

--- a/content/blog/shaded-seats-rogers-centre.mdx
+++ b/content/blog/shaded-seats-rogers-centre.mdx
@@ -2,6 +2,7 @@
 title: "Shaded Seats at Rogers Centre: Complete Guide"
 description: "Find the best shaded seats at Rogers Centre. Learn how the Blue Jays' retractable roof affects sun exposure and which sections offer shade when the roof is open."
 date: "2025-09-15"
+dateModified: "2026-07-17"
 author: "The Shadium Team"
 category: "stadium-guides"
 tags: ["rogers-centre", "toronto-blue-jays", "mlb", "shaded-seats", "day-games", "toronto"]

--- a/content/blog/shaded-seats-steinbrenner-field.mdx
+++ b/content/blog/shaded-seats-steinbrenner-field.mdx
@@ -1,14 +1,17 @@
 ---
 title: "Shaded Seats at George M. Steinbrenner Field: Complete Guide (Rays Temporary Home)"
-description: "Find the best shaded seats at George M. Steinbrenner Field, the Tampa Bay Rays' temporary home for 2025. Learn which sections offer shade during day games."
+description: "Find the best shaded seats at George M. Steinbrenner Field, the Tampa Bay Rays' 2025 temporary home. Note: the Rays returned to Tropicana Field for the 2026 season."
 date: "2025-09-15"
+dateModified: "2026-07-17"
 author: "The Shadium Team"
 category: "stadium-guides"
 tags: ["steinbrenner-field", "tampa-bay-rays", "mlb", "shaded-seats", "day-games", "tampa"]
-excerpt: "George M. Steinbrenner Field became the Tampa Bay Rays' temporary home for 2025 after Hurricane Milton severely damaged Tropicana Field. This intimate spring training ballpark has a unique northwest-facing orientation that puts the first base side in afternoon shade."
+excerpt: "George M. Steinbrenner Field was the Tampa Bay Rays' temporary home for the 2025 season after Hurricane Milton severely damaged Tropicana Field. The Rays returned to a repaired Tropicana Field for 2026. This intimate spring training ballpark has a northwest-facing orientation that puts the first base side in afternoon shade."
 ---
 
-## George M. Steinbrenner Field: The Rays' Temporary Home
+> **2026 update:** The Tampa Bay Rays returned to a repaired Tropicana Field for the 2026 season (home opener April 6, 2026). This guide covers their 2025 temporary home at Steinbrenner Field, which remains the spring-training home of the New York Yankees and the regular-season home of the Class-A Tampa Tarpons.
+
+## George M. Steinbrenner Field: The Rays' 2025 Temporary Home
 
 When Hurricane Milton struck Florida in October 2024, Tropicana Field in St. Petersburg sustained severe damage, leaving the Tampa Bay Rays without a stadium for the 2025 season. The solution: temporarily relocating to George M. Steinbrenner Field in Tampa, the spring training home of the New York Yankees.
 

--- a/content/blog/shaded-seats-sutter-health-park.mdx
+++ b/content/blog/shaded-seats-sutter-health-park.mdx
@@ -1,16 +1,17 @@
 ---
 title: "Shaded Seats at Sutter Health Park: Complete Guide (Athletics in Sacramento)"
-description: "Find the best shaded seats at Sutter Health Park, the Oakland Athletics' temporary home in Sacramento. Learn which sections offer shade during hot Sacramento day games."
+description: "Find the best shaded seats at Sutter Health Park, the Athletics' temporary home in West Sacramento. Learn which sections offer shade during hot Sacramento day games."
 date: "2025-09-15"
+dateModified: "2026-07-17"
 author: "The Shadium Team"
 category: "stadium-guides"
-tags: ["sutter-health-park", "oakland-athletics", "mlb", "shaded-seats", "day-games", "sacramento"]
-excerpt: "The Oakland Athletics relocated to Sutter Health Park in Sacramento for 2025 while their Las Vegas stadium is under construction. This compact ballpark has a north-northeast-facing orientation, meaning the seats behind home plate are your best bet for afternoon shade during Sacramento's scorching summer games."
+tags: ["sutter-health-park", "athletics", "mlb", "shaded-seats", "day-games", "sacramento"]
+excerpt: "The Athletics relocated from Oakland to West Sacramento's Sutter Health Park in 2025 — their temporary home through at least 2027 while a Las Vegas stadium is built. This compact ballpark has a north-northeast-facing orientation, meaning the seats behind home plate are your best bet for afternoon shade during Sacramento's scorching summer games."
 ---
 
 ## Sutter Health Park: Baseball's Most Unusual Venue
 
-Major league baseball in Sacramento is a new chapter for the Oakland Athletics, who relocated to Sutter Health Park for the 2025 season while their permanent Las Vegas stadium is built. Sutter Health Park is normally home to the Sacramento River Cats, the Giants' Triple-A affiliate, so it's one of the smallest venues in MLB history to host regular-season major league games, with a capacity of around 14,014.
+Major league baseball in Sacramento is a new chapter for the Athletics, who relocated from Oakland to Sutter Health Park starting in 2025 (their second season there is 2026) while their permanent Las Vegas stadium is built. Sutter Health Park is normally home to the Sacramento River Cats, the Giants' Triple-A affiliate, so it's one of the smallest venues in MLB history to host regular-season major league games, with a capacity of around 14,014.
 
 The intimate setting creates a unique atmosphere — every fan is close to the action — but it also means the stadium's shade coverage is more limited than at a full-scale MLB ballpark. And shade matters a lot here: Sacramento is one of the hottest major league markets in the country.
 

--- a/content/blog/shaded-seats-t-mobile-park.mdx
+++ b/content/blog/shaded-seats-t-mobile-park.mdx
@@ -2,6 +2,7 @@
 title: "Shaded Seats at T-Mobile Park: Complete Guide"
 description: "Find the best shaded seats at T-Mobile Park in Seattle. Learn how the northeast orientation and retractable roof affect shade, plus pro tips for Mariners day games."
 date: "2025-09-15"
+dateModified: "2026-07-17"
 author: "The Shadium Team"
 category: "stadium-guides"
 tags: ["t-mobile-park", "seattle-mariners", "mlb", "shaded-seats", "day-games", "seattle"]

--- a/content/blog/shaded-seats-target-field.mdx
+++ b/content/blog/shaded-seats-target-field.mdx
@@ -2,6 +2,7 @@
 title: "Shaded Seats at Target Field: Complete Guide"
 description: "Find the best shaded seats at Target Field in Minneapolis. Learn how the due-east orientation affects afternoon shade and get tips for Twins day games in downtown Minnesota."
 date: "2025-09-15"
+dateModified: "2026-07-17"
 author: "The Shadium Team"
 category: "stadium-guides"
 tags: ["target-field", "minnesota-twins", "mlb", "shaded-seats", "day-games", "minneapolis"]

--- a/content/blog/shaded-seats-truist-park.mdx
+++ b/content/blog/shaded-seats-truist-park.mdx
@@ -2,6 +2,7 @@
 title: "Shaded Seats at Truist Park: Complete Guide"
 description: "Find the best shaded seats at Truist Park in Atlanta. Learn where to sit for afternoon relief from Georgia heat at the Braves' modern ballpark."
 date: "2025-09-15"
+dateModified: "2026-07-17"
 author: "The Shadium Team"
 category: "stadium-guides"
 tags: ["truist-park", "atlanta-braves", "mlb", "shaded-seats", "day-games", "atlanta"]

--- a/content/blog/shaded-seats-wrigley-field.mdx
+++ b/content/blog/shaded-seats-wrigley-field.mdx
@@ -2,6 +2,7 @@
 title: "Shaded Seats at Wrigley Field: Complete Guide"
 description: "Navigate Wrigley Field's limited shade options. Learn where to sit for afternoon relief from the sun at baseball's most historic stadium in Chicago."
 date: "2025-09-15"
+dateModified: "2026-07-17"
 author: "The Shadium Team"
 category: "stadium-guides"
 tags: ["wrigley-field", "chicago-cubs", "mlb", "shaded-seats", "day-games", "chicago"]

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -6,12 +6,23 @@ import readingTime from 'reading-time';
 
 const postsDirectory = path.join(process.cwd(), 'content/blog');
 
+// Parse a frontmatter date. Bare "YYYY-MM-DD" values are parsed as LOCAL noon so
+// the displayed calendar date can't shift a day under a non-UTC build timezone
+// (new Date("2026-07-17") is UTC midnight, which renders as the 16th in EDT/PDT).
+function parseFrontmatterDate(value: unknown): Date | null {
+  if (!value) return null;
+  const s = String(value);
+  return /^\d{4}-\d{2}-\d{2}$/.test(s) ? new Date(`${s}T12:00:00`) : new Date(s);
+}
+
 export interface BlogPost {
   slug: string;
   title: string;
   description: string;
   date: string;
   dateISO: string;
+  dateModified?: string;
+  dateModifiedISO?: string;
   author: string;
   category: string;
   tags: string[];
@@ -40,7 +51,9 @@ export function getPostBySlug(slug: string): BlogPost | null {
     
     const stats = readingTime(content);
     
-    const rawDate = data.date ? new Date(data.date) : null;
+    const rawDate = parseFrontmatterDate(data.date);
+    // Optional correction date — only present on posts we substantively updated.
+    const rawModified = parseFrontmatterDate(data.dateModified);
 
     return {
       slug: realSlug,
@@ -48,6 +61,8 @@ export function getPostBySlug(slug: string): BlogPost | null {
       description: data.description || '',
       date: rawDate ? format(rawDate, 'MMMM d, yyyy') : '',
       dateISO: rawDate ? rawDate.toISOString() : '',
+      dateModified: rawModified ? format(rawModified, 'MMMM d, yyyy') : undefined,
+      dateModifiedISO: rawModified ? rawModified.toISOString() : undefined,
       author: data.author || 'The Shadium Team',
       category: data.category || 'general',
       tags: data.tags || [],

--- a/locales/en.json
+++ b/locales/en.json
@@ -453,7 +453,7 @@
     "teams": {
       "angels": "Los Angeles Angels",
       "astros": "Houston Astros",
-      "athletics": "Oakland Athletics",
+      "athletics": "Athletics",
       "bluejays": "Toronto Blue Jays",
       "braves": "Atlanta Braves",
       "brewers": "Milwaukee Brewers",
@@ -511,7 +511,7 @@
       "royals": "Kauffman Stadium",
       "tigers": "Comerica Park",
       "twins": "Target Field",
-      "whitesox": "Guaranteed Rate Field",
+      "whitesox": "Rate Field",
       "yankees": "Yankee Stadium"
     }
   },

--- a/locales/es.json
+++ b/locales/es.json
@@ -442,7 +442,7 @@
     "teams": {
       "angels": "Angelinos de Los Ángeles",
       "astros": "Astros de Houston",
-      "athletics": "Atléticos de Oakland",
+      "athletics": "Atléticos",
       "bluejays": "Azulejos de Toronto",
       "braves": "Bravos de Atlanta",
       "brewers": "Cerveceros de Milwaukee",
@@ -500,7 +500,7 @@
       "royals": "Estadio Kauffman",
       "tigers": "Parque Comerica",
       "twins": "Campo Target",
-      "whitesox": "Campo Guaranteed Rate",
+      "whitesox": "Rate Field",
       "yankees": "Estadio Yankee"
     }
   },

--- a/public/sitemap-blog.xml
+++ b/public/sitemap-blog.xml
@@ -20,31 +20,31 @@
   </url>
   <url>
     <loc>https://theshadium.com/blog/shaded-seats-american-family-field</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://theshadium.com/blog/shaded-seats-angel-stadium</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://theshadium.com/blog/shaded-seats-busch-stadium</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://theshadium.com/blog/shaded-seats-camden-yards</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://theshadium.com/blog/shaded-seats-chase-field</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -56,7 +56,7 @@
   </url>
   <url>
     <loc>https://theshadium.com/blog/shaded-seats-citizens-bank-park</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -68,7 +68,7 @@
   </url>
   <url>
     <loc>https://theshadium.com/blog/shaded-seats-coors-field</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -86,37 +86,37 @@
   </url>
   <url>
     <loc>https://theshadium.com/blog/shaded-seats-great-american-ball-park</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://theshadium.com/blog/shaded-seats-guaranteed-rate-field</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://theshadium.com/blog/shaded-seats-kauffman-stadium</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://theshadium.com/blog/shaded-seats-loanDepot-park</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://theshadium.com/blog/shaded-seats-minute-maid-park</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://theshadium.com/blog/shaded-seats-nationals-park</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -128,61 +128,61 @@
   </url>
   <url>
     <loc>https://theshadium.com/blog/shaded-seats-petco-park</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://theshadium.com/blog/shaded-seats-pnc-park</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://theshadium.com/blog/shaded-seats-progressive-field</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://theshadium.com/blog/shaded-seats-rogers-centre</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://theshadium.com/blog/shaded-seats-steinbrenner-field</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://theshadium.com/blog/shaded-seats-sutter-health-park</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://theshadium.com/blog/shaded-seats-t-mobile-park</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://theshadium.com/blog/shaded-seats-target-field</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://theshadium.com/blog/shaded-seats-truist-park</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://theshadium.com/blog/shaded-seats-wrigley-field</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -32,8 +32,11 @@ try {
       const raw = fs.readFileSync(fullPath, 'utf-8');
       const { data } = matter(raw);
       const slug = f.replace(/\.mdx$/, '');
-      const dateISO = data.date
-        ? new Date(data.date).toISOString().split('T')[0]
+      // Prefer dateModified (correction date) over the original publish date so
+      // Google sees an accurate lastmod for posts we substantively updated.
+      const effective = data.dateModified || data.date;
+      const dateISO = effective
+        ? new Date(effective).toISOString().split('T')[0]
         : new Date(fs.statSync(fullPath).mtime).toISOString().split('T')[0];
       return { slug, lastmod: dateISO };
     });

--- a/venues.json
+++ b/venues.json
@@ -66,7 +66,7 @@
       "id": "athletics",
       "name": "Sutter Health Park",
       "league": "MLB",
-      "team": "Oakland Athletics",
+      "team": "Athletics",
       "city": "Sacramento",
       "state": "CA",
       "latitude": 38.5664,
@@ -844,7 +844,7 @@
     },
     {
       "id": "whitesox",
-      "name": "Guaranteed Rate Field",
+      "name": "Rate Field",
       "league": "MLB",
       "team": "Chicago White Sox",
       "city": "Chicago",
@@ -2867,7 +2867,7 @@
       "league": "MiLB",
       "team": "Las Vegas Aviators",
       "alternateTeams": [
-        "Oakland Athletics"
+        "Athletics"
       ],
       "city": "Las Vegas",
       "state": "NV",
@@ -4019,7 +4019,7 @@
       "league": "MiLB",
       "team": "Midland RockHounds",
       "alternateTeams": [
-        "Oakland Athletics"
+        "Athletics"
       ],
       "city": "Midland",
       "state": "TX",
@@ -4883,7 +4883,7 @@
       "league": "MiLB",
       "team": "Lansing Lugnuts",
       "alternateTeams": [
-        "Oakland Athletics"
+        "Athletics"
       ],
       "city": "Lansing",
       "state": "MI",
@@ -5531,7 +5531,7 @@
       "league": "MiLB",
       "team": "Stockton Ports",
       "alternateTeams": [
-        "Oakland Athletics"
+        "Athletics"
       ],
       "city": "Stockton",
       "state": "CA",


### PR DESCRIPTION
## Summary
Round 2 of the audit follow-up. Branch merges via **merge commit** (squash now disabled repo-wide to avoid the Vercel content-dedup that skipped the PR #74 production deploy).

### 1. Mobile section tables
On screens <768px the 150+-row "All Sections" table is replaced by **collapsible cards grouped by seating level** (Field / Lower / Club / Upper / Suites), each showing the tier symbol, star rating, and notes. Desktop keeps the table. Built with native `<details>` — server-rendered, no JS, fully crawlable. ≥44px tap targets, ≥16px body text, zero horizontal overflow. A shared `sectionRowData()` keeps table and cards identical.

### 2. 2026 venue names
Primary data (`stadiums.ts`/`unifiedVenues.ts`) was already correct for 2026 (Rays back at Tropicana Field — home opener Apr 6, 2026; Athletics = "Athletics" @ Sutter Health Park; White Sox = "Rate Field"). Fixed **stale secondary references**:
- `locales/en.json` + `es.json` (athletics team, whitesox stadium)
- `venues.json` (team field + 4 affiliate parent-club labels)
- Blog posts: **sutter-health-park** (drop "Oakland"), **guaranteed-rate-field** (→ "Rate Field" everywhere + fixed a backwards third-base shade claim to first base, confirmed by the sun-model *and* shadedseats.com), **steinbrenner-field** (2026 "Rays returned to Tropicana" note).

### 3. Blog freshness
New optional `dateModified` frontmatter on the **23 corrected posts** (2026-07-17), rendered as an "Updated {date}" badge, wired into the `BlogPosting` schema `dateModified` and sitemap `lastmod`. Untouched posts keep their original date (no faked dates). Also fixed a latent timezone off-by-one in date display (bare `YYYY-MM-DD` now parsed as local noon).

### 4. Recrawl prep
`sitemap-stadiums.xml` already emits **only canonical `/stadium/` URLs** (182 URLs, 0 `/venue/`); blog `lastmod`s now reflect the correction date. GSC click-by-click checklist delivered separately.

## Verification
- `tsc` clean · **666/666** tests · production build (460 pages) OK
- Built HTML confirmed: mobile cards render, "Updated" badge on corrected posts only, correct dates (tz-independent), `/stadium/`-only sitemap, schema `dateModified`
- Mobile Lighthouse captured (local `next start`, which understates perf vs Vercel edge); real production numbers to follow in the report

🤖 Generated with [Claude Code](https://claude.com/claude-code)