### PR TITLE
fix: Fenway Field Box/Loge/SRO are day-shade, not covered structures

### DIFF
--- a/scripts/auditCoverageContradictions.ts
+++ b/scripts/auditCoverageContradictions.ts
@@ -34,7 +34,33 @@ const ROOF = new Map(MLB_STADIUMS.map((s) => [s.id, s.roof]));
 //            exposed, and that is already covered:false.
 const REVIEWED_OK = new Set(['redsox']);
 
-type Sec = { name?: string; level?: string; covered?: boolean; fullyCovered?: boolean; partialCoverage?: unknown };
+// Second-pass allow-list: for venues with a documented, section-level covered
+// list, a predicate returning whether a section is EXPECTED to be a covered
+// structure per research. Any covered=true section OUTSIDE the list (or any
+// listed section NOT covered) is flagged — this catches mislabeled non-open-air
+// NAMES (Field Box, Loge Box, general SRO) that the name pass above can't see.
+const RESEARCHED_COVERED: Record<string, (s: Sec) => boolean> = {
+  // Fenway Park — rateyourseats.com/fenway-park documents covered seating as:
+  // all Pavilion Boxes (PB), Home Plate Pavilion Club (HPPC), Dell/EMC Club
+  // (EMCC), and all Grandstand (GS) except GS-33. Plus the two Pavilion-level
+  // SRO (under the Pavilion roof) and the indoor Royal Rooters Club. Everything
+  // else — Field Box, Loge Box, Monster, Bleachers, RF Box/Roof, SSPC, Pavilion
+  // Reserved, general SRO — is NOT a covered structure.
+  redsox: (s) => {
+    const id = s.id || '';
+    return (
+      /^PB-\d+$/.test(id) ||
+      /^HPPC-\d+$/.test(id) ||
+      /^EMCC-\d+$/.test(id) ||
+      /^GS-(?:[1-9]|1\d|2\d|3[0-2])$/.test(id) || // Grandstand 1-32 (not GS-33)
+      id === 'FIRST-BASE-PAV-SRO' ||
+      id === 'THIRD-BASE-PAV-SRO' ||
+      id === 'ROYAL-ROOTERS'
+    );
+  },
+};
+
+type Sec = { id?: string; name?: string; level?: string; covered?: boolean; fullyCovered?: boolean; partialCoverage?: unknown };
 
 // Mirror of StadiumPageSSR.shadeTierOf.
 function tier(s: Sec): 'covered' | 'partial' | 'exposed' {
@@ -73,24 +99,54 @@ async function main() {
     }
   }
 
+  // --- Pass 2: cross-reference covered=true flags against researched lists. ---
+  const coveredFindings: Array<{ id: string; section: string; issue: string }> = [];
+  for (const v of ALL_UNIFIED_VENUES) {
+    const pred = RESEARCHED_COVERED[v.id];
+    if (!pred) continue;
+    const secs = await sectionsFor(v);
+    for (const s of secs) {
+      if (!s?.name) continue;
+      const isCovered = s.covered === true;
+      const expected = pred(s);
+      if (isCovered && !expected) {
+        coveredFindings.push({ id: v.id, section: s.name, issue: 'covered=true but NOT in researched covered list' });
+      } else if (!isCovered && expected) {
+        coveredFindings.push({ id: v.id, section: s.name, issue: 'researched-covered but covered=false' });
+      }
+    }
+  }
+
   console.log(`Scanned ${ALL_UNIFIED_VENUES.length} venues (MLB + MiLB + NFL).`);
   console.log(`Skipped ${roofDependentSkipped} retractable/fixed-roof park(s) (coverage is roof-state, not overhang) and ${reviewedSkipped} verified-exception park(s).\n`);
+
+  console.log('── Pass 1: open-air NAMES rendering above Exposed ──');
   if (!findings.length) {
-    console.log('✓ No open-air sections rendering above Exposed.');
-    process.exit(0);
+    console.log('✓ No open-air-named sections rendering above Exposed.\n');
+  } else {
+    const byVenue = new Map<string, typeof findings>();
+    for (const f of findings) {
+      const arr = byVenue.get(f.id) ?? [];
+      arr.push(f);
+      byVenue.set(f.id, arr);
+    }
+    console.log(`⚠ ${findings.length} open-air section(s) above Exposed across ${byVenue.size} venue(s):`);
+    for (const [id, arr] of Array.from(byVenue.entries())) {
+      console.log(`  [${arr[0].league}] ${id} (${arr[0].name}):`);
+      for (const f of arr) console.log(`      • ${f.section} -> ${f.tier} (should be Exposed)`);
+    }
+    console.log('');
   }
-  const byVenue = new Map<string, typeof findings>();
-  for (const f of findings) {
-    const arr = byVenue.get(f.id) ?? [];
-    arr.push(f);
-    byVenue.set(f.id, arr);
+
+  console.log(`── Pass 2: covered flags vs researched lists (${Object.keys(RESEARCHED_COVERED).join(', ')}) ──`);
+  if (!coveredFindings.length) {
+    console.log('✓ All covered flags match the researched covered lists.');
+  } else {
+    console.log(`⚠ ${coveredFindings.length} covered-flag mismatch(es):`);
+    for (const f of coveredFindings) console.log(`  [${f.id}] ${f.section} — ${f.issue}`);
   }
-  console.log(`⚠ ${findings.length} open-air section(s) above Exposed across ${byVenue.size} venue(s):\n`);
-  for (const [id, arr] of Array.from(byVenue.entries())) {
-    console.log(`  [${arr[0].league}] ${id} (${arr[0].name}):`);
-    for (const f of arr) console.log(`      • ${f.section} -> ${f.tier} (should be Exposed)`);
-  }
-  process.exit(1);
+
+  process.exit(findings.length || coveredFindings.length ? 1 : 0);
 }
 
 main();

--- a/src/data/sections/mlb/__tests__/redsox.test.ts
+++ b/src/data/sections/mlb/__tests__/redsox.test.ts
@@ -174,19 +174,22 @@ describe('redsoxSections — Fenway Park real seating data', () => {
       expect(sspc.every((s) => !s.covered)).toBe(true);
     });
 
-    it('marks Field Box 39-50 covered (only inner FB sections under press box)', () => {
+    it('marks Field Box 39-50 NOT covered structures (day-shade, not covered per RateYourSeats)', () => {
+      // Field Box gets press-box/Pavilion-stack shade for day games but is not a
+      // covered structure — RateYourSeats' covered list is PB / HPPC / EMCC /
+      // Grandstand-except-GS33 only. Reclassified to covered=false; the split UI
+      // marks FB-39..50 as partial (day-game shade).
       for (let n = 39; n <= 50; n++) {
-        expect(sectionById(`FB-${n}`).covered).toBe(true);
+        expect(sectionById(`FB-${n}`).covered).toBe(false);
       }
-      // Sections outside that range NOT covered.
       ['FB-38', 'FB-51', 'FB-1', 'FB-82'].forEach((id) => {
         expect(sectionById(id).covered).toBe(false);
       });
     });
 
-    it('marks Loge Box 123-136 covered (consistently shaded behind HP)', () => {
+    it('marks Loge Box 123-136 NOT covered structures (day-shade, not covered per RateYourSeats)', () => {
       for (let n = 123; n <= 136; n++) {
-        expect(sectionById(`LB-${n}`).covered).toBe(true);
+        expect(sectionById(`LB-${n}`).covered).toBe(false);
       }
       ['LB-122', 'LB-137', 'LB-98', 'LB-165'].forEach((id) => {
         expect(sectionById(id).covered).toBe(false);

--- a/src/data/sections/mlb/redsox.ts
+++ b/src/data/sections/mlb/redsox.ts
@@ -21,14 +21,17 @@
 //
 // Fenway-specific architecture baked into the data:
 //   • Field Box (FB-1 through FB-82): 82 sections wrapping the entire bowl
-//     foul-line to foul-line. FB-39 through FB-50 marked covered=true —
-//     consistently shaded by the press-box / Pavilion stack overhead per
-//     shadedseats ("upper rows of FB-39-50 are shaded for 1pm games"). All
-//     other FB sections uncovered.
+//     foul-line to foul-line. FB-39 through FB-50 are NOT covered structures
+//     (RateYourSeats lists Fenway's covered seating as the Pavilion Boxes,
+//     HPPC, Dell/EMC Club, and all Grandstand but GS33 — no Field Box). They
+//     get press-box/Pavilion-stack SHADE for afternoon day games, so they are
+//     covered=false here and flagged day-shade (partial) in the split UI file.
+//     All other FB sections uncovered.
 //   • Loge Box (LB-98 through LB-165, skipping LB-156 — no such section
-//     published): 67 sections in the second tier. LB-123 through LB-136
-//     marked covered=true (consistently shaded behind HP); others
-//     uncovered.
+//     published): 67 sections in the second tier. LB-123 through LB-136 get
+//     day-game shade behind HP but are NOT covered structures (not in the
+//     RateYourSeats covered list) — covered=false, flagged day-shade (partial)
+//     in the split UI file. Others uncovered.
 //   • Grandstand (GS-1 through GS-33): 33 iconic wooden-seat sections.
 //     ALL covered=true EXCEPT GS-33 (per RateYourSeats: "all Grandstand
 //     sections except GS33 are covered"). GS-33 sits at the LF/Green
@@ -58,7 +61,9 @@
 //     behind HP. Covered, level=club, height=0.
 //   • Standing areas (Hornitos Cantina, Coca-Cola Corner SRO, Green Monster
 //     SRO, Right Field Roof Box/Deck SRO, Roof Deck Tables, First/Third
-//     Base Pavilion SRO, general SRO): mixed coverage per location.
+//     Base Pavilion SRO, general SRO): mixed coverage per location. First/Third
+//     Base Pavilion SRO sit under the Pavilion roof (covered=true); the general
+//     SRO is not a covered structure (covered=false, day-shade partial in UI).
 //
 // Section count: 275, far exceeding the typical MLB bowl. This is real for
 // Fenway because of dense sub-sectioning of the Field Box and Loge Box
@@ -195,18 +200,18 @@ const SECTIONS: SectionInput[] = [
   { id: 'FB-36', name: 'Field Box 36', level: 'field', compass: 218, span: 3, covered: false, distance: 80,  height: 8 },
   { id: 'FB-37', name: 'Field Box 37', level: 'field', compass: 221, span: 3, covered: false, distance: 80,  height: 8 },
   { id: 'FB-38', name: 'Field Box 38', level: 'field', compass: 225, span: 3, covered: false, distance: 80,  height: 8 },
-  { id: 'FB-39', name: 'Field Box 39', level: 'field', compass: 228, span: 3, covered: true,  distance: 80,  height: 8 },
-  { id: 'FB-40', name: 'Field Box 40', level: 'field', compass: 232, span: 3, covered: true,  distance: 80,  height: 8 },
-  { id: 'FB-41', name: 'Field Box 41', level: 'field', compass: 235, span: 3, covered: true,  distance: 80,  height: 8 },
-  { id: 'FB-42', name: 'Field Box 42', level: 'field', compass: 239, span: 3, covered: true,  distance: 80,  height: 8 },
-  { id: 'FB-43', name: 'Field Box 43', level: 'field', compass: 242, span: 3, covered: true,  distance: 80,  height: 8 },
-  { id: 'FB-44', name: 'Field Box 44', level: 'field', compass: 246, span: 3, covered: true,  distance: 80,  height: 8 },
-  { id: 'FB-45', name: 'Field Box 45', level: 'field', compass: 249, span: 3, covered: true,  distance: 80,  height: 8 },
-  { id: 'FB-46', name: 'Field Box 46', level: 'field', compass: 252, span: 3, covered: true,  distance: 81,  height: 8 },
-  { id: 'FB-47', name: 'Field Box 47', level: 'field', compass: 256, span: 3, covered: true,  distance: 82,  height: 8 },
-  { id: 'FB-48', name: 'Field Box 48', level: 'field', compass: 259, span: 3, covered: true,  distance: 84,  height: 8 },
-  { id: 'FB-49', name: 'Field Box 49', level: 'field', compass: 263, span: 3, covered: true,  distance: 86,  height: 8 },
-  { id: 'FB-50', name: 'Field Box 50', level: 'field', compass: 266, span: 3, covered: true,  distance: 88,  height: 8 },
+  { id: 'FB-39', name: 'Field Box 39', level: 'field', compass: 228, span: 3, covered: false,  distance: 80,  height: 8 },
+  { id: 'FB-40', name: 'Field Box 40', level: 'field', compass: 232, span: 3, covered: false,  distance: 80,  height: 8 },
+  { id: 'FB-41', name: 'Field Box 41', level: 'field', compass: 235, span: 3, covered: false,  distance: 80,  height: 8 },
+  { id: 'FB-42', name: 'Field Box 42', level: 'field', compass: 239, span: 3, covered: false,  distance: 80,  height: 8 },
+  { id: 'FB-43', name: 'Field Box 43', level: 'field', compass: 242, span: 3, covered: false,  distance: 80,  height: 8 },
+  { id: 'FB-44', name: 'Field Box 44', level: 'field', compass: 246, span: 3, covered: false,  distance: 80,  height: 8 },
+  { id: 'FB-45', name: 'Field Box 45', level: 'field', compass: 249, span: 3, covered: false,  distance: 80,  height: 8 },
+  { id: 'FB-46', name: 'Field Box 46', level: 'field', compass: 252, span: 3, covered: false,  distance: 81,  height: 8 },
+  { id: 'FB-47', name: 'Field Box 47', level: 'field', compass: 256, span: 3, covered: false,  distance: 82,  height: 8 },
+  { id: 'FB-48', name: 'Field Box 48', level: 'field', compass: 259, span: 3, covered: false,  distance: 84,  height: 8 },
+  { id: 'FB-49', name: 'Field Box 49', level: 'field', compass: 263, span: 3, covered: false,  distance: 86,  height: 8 },
+  { id: 'FB-50', name: 'Field Box 50', level: 'field', compass: 266, span: 3, covered: false,  distance: 88,  height: 8 },
   { id: 'FB-51', name: 'Field Box 51', level: 'field', compass: 270, span: 3, covered: false, distance: 90,  height: 8 },
   { id: 'FB-52', name: 'Field Box 52', level: 'field', compass: 273, span: 3, covered: false, distance: 92,  height: 8 },
   { id: 'FB-53', name: 'Field Box 53', level: 'field', compass: 277, span: 3, covered: false, distance: 95,  height: 8 },
@@ -266,20 +271,20 @@ const SECTIONS: SectionInput[] = [
   { id: 'LB-120', name: 'Loge Box 120', level: 'lower', compass: 185, span: 4, covered: false, distance: 128, height: 22 },
   { id: 'LB-121', name: 'Loge Box 121', level: 'lower', compass: 189, span: 4, covered: false, distance: 122, height: 22 },
   { id: 'LB-122', name: 'Loge Box 122', level: 'lower', compass: 193, span: 4, covered: false, distance: 118, height: 22 },
-  { id: 'LB-123', name: 'Loge Box 123', level: 'lower', compass: 197, span: 4, covered: true,  distance: 115, height: 22 },
-  { id: 'LB-124', name: 'Loge Box 124', level: 'lower', compass: 201, span: 4, covered: true,  distance: 112, height: 22 },
-  { id: 'LB-125', name: 'Loge Box 125', level: 'lower', compass: 205, span: 4, covered: true,  distance: 110, height: 22 },
-  { id: 'LB-126', name: 'Loge Box 126', level: 'lower', compass: 209, span: 4, covered: true,  distance: 108, height: 22 },
-  { id: 'LB-127', name: 'Loge Box 127', level: 'lower', compass: 213, span: 4, covered: true,  distance: 106, height: 22 },
-  { id: 'LB-128', name: 'Loge Box 128', level: 'lower', compass: 217, span: 4, covered: true,  distance: 105, height: 22 },
-  { id: 'LB-129', name: 'Loge Box 129', level: 'lower', compass: 221, span: 4, covered: true,  distance: 104, height: 22 },
-  { id: 'LB-130', name: 'Loge Box 130', level: 'lower', compass: 225, span: 4, covered: true,  distance: 103, height: 22 },
-  { id: 'LB-131', name: 'Loge Box 131', level: 'lower', compass: 229, span: 4, covered: true,  distance: 102, height: 22 },
-  { id: 'LB-132', name: 'Loge Box 132', level: 'lower', compass: 233, span: 4, covered: true,  distance: 102, height: 22 },
-  { id: 'LB-133', name: 'Loge Box 133', level: 'lower', compass: 237, span: 4, covered: true,  distance: 103, height: 22 },
-  { id: 'LB-134', name: 'Loge Box 134', level: 'lower', compass: 241, span: 4, covered: true,  distance: 104, height: 22 },
-  { id: 'LB-135', name: 'Loge Box 135', level: 'lower', compass: 245, span: 4, covered: true,  distance: 105, height: 22 },
-  { id: 'LB-136', name: 'Loge Box 136', level: 'lower', compass: 249, span: 4, covered: true,  distance: 107, height: 22 },
+  { id: 'LB-123', name: 'Loge Box 123', level: 'lower', compass: 197, span: 4, covered: false,  distance: 115, height: 22 },
+  { id: 'LB-124', name: 'Loge Box 124', level: 'lower', compass: 201, span: 4, covered: false,  distance: 112, height: 22 },
+  { id: 'LB-125', name: 'Loge Box 125', level: 'lower', compass: 205, span: 4, covered: false,  distance: 110, height: 22 },
+  { id: 'LB-126', name: 'Loge Box 126', level: 'lower', compass: 209, span: 4, covered: false,  distance: 108, height: 22 },
+  { id: 'LB-127', name: 'Loge Box 127', level: 'lower', compass: 213, span: 4, covered: false,  distance: 106, height: 22 },
+  { id: 'LB-128', name: 'Loge Box 128', level: 'lower', compass: 217, span: 4, covered: false,  distance: 105, height: 22 },
+  { id: 'LB-129', name: 'Loge Box 129', level: 'lower', compass: 221, span: 4, covered: false,  distance: 104, height: 22 },
+  { id: 'LB-130', name: 'Loge Box 130', level: 'lower', compass: 225, span: 4, covered: false,  distance: 103, height: 22 },
+  { id: 'LB-131', name: 'Loge Box 131', level: 'lower', compass: 229, span: 4, covered: false,  distance: 102, height: 22 },
+  { id: 'LB-132', name: 'Loge Box 132', level: 'lower', compass: 233, span: 4, covered: false,  distance: 102, height: 22 },
+  { id: 'LB-133', name: 'Loge Box 133', level: 'lower', compass: 237, span: 4, covered: false,  distance: 103, height: 22 },
+  { id: 'LB-134', name: 'Loge Box 134', level: 'lower', compass: 241, span: 4, covered: false,  distance: 104, height: 22 },
+  { id: 'LB-135', name: 'Loge Box 135', level: 'lower', compass: 245, span: 4, covered: false,  distance: 105, height: 22 },
+  { id: 'LB-136', name: 'Loge Box 136', level: 'lower', compass: 249, span: 4, covered: false,  distance: 107, height: 22 },
   { id: 'LB-137', name: 'Loge Box 137', level: 'lower', compass: 253, span: 4, covered: false, distance: 110, height: 22 },
   { id: 'LB-138', name: 'Loge Box 138', level: 'lower', compass: 257, span: 4, covered: false, distance: 114, height: 22 },
   { id: 'LB-139', name: 'Loge Box 139', level: 'lower', compass: 261, span: 4, covered: false, distance: 118, height: 22 },
@@ -460,7 +465,7 @@ const SECTIONS: SectionInput[] = [
   { id: 'ROOF-DECK-TABLES',     name: 'Roof Deck Tables',             level: 'standing', compass: 78,  span: 8,  covered: false, distance: 310, height: 65 },
   { id: 'FIRST-BASE-PAV-SRO',   name: 'First Base Pavilion SRO',      level: 'standing', compass: 192, span: 10, covered: true,  distance: 175, height: 65 },
   { id: 'THIRD-BASE-PAV-SRO',   name: 'Third Base Pavilion SRO',      level: 'standing', compass: 272, span: 10, covered: true,  distance: 175, height: 65 },
-  { id: 'SRO',                  name: 'Standing Room Only (general)', level: 'standing', compass: 232, span: 30, covered: true,  distance: 200, height: 50 },
+  { id: 'SRO',                  name: 'Standing Room Only (general)', level: 'standing', compass: 232, span: 30, covered: false,  distance: 200, height: 50 },
 ];
 
 export const redsoxSections: DetailedSection[] = SECTIONS.map((s) => {

--- a/src/data/stadiumSections-split/redsox.ts
+++ b/src/data/stadiumSections-split/redsox.ts
@@ -17,6 +17,19 @@ import { redsoxSections } from '../sections/mlb/redsox';
 
 type Level = StadiumSection['level'];
 
+// Field/Loge infield boxes + general SRO that are NOT covered structures (no
+// roof/overhang) but sit in the shadow of the stacked press-box / Pavilion for
+// afternoon day games. Per RateYourSeats, Fenway's COVERED seating is only the
+// Pavilion Boxes, Home Plate Pavilion Club, Dell Technologies (EMC) Club, and
+// all Grandstand except GS33 — Field Box and Loge Box are not covered. So these
+// are marked covered:false at the source and rendered as PARTIAL (day-game
+// shade), not as covered structures and not as fully exposed.
+const DAY_SHADED = new Set<string>([
+  ...Array.from({ length: 12 }, (_, i) => `FB-${39 + i}`), // FB-39..50
+  ...Array.from({ length: 14 }, (_, i) => `LB-${123 + i}`), // LB-123..136
+  'SRO',
+]);
+
 function projectLevel(level: string): Level {
   return (level === 'standing' ? 'field' : level) as Level;
 }
@@ -43,6 +56,10 @@ export const stadiumSections = {
     angleSpan: s.angleSpan,
     rows: s.rows.length,
     covered: s.covered,
+    // Day-game shade from the press-box/Pavilion stack — shaded but not covered.
+    ...(DAY_SHADED.has(s.id)
+      ? { partialCoverage: true, coveredRows: 'day games only (press-box shade)' }
+      : {}),
     price: priceFor(s.level),
   })),
 };


### PR DESCRIPTION
## Context
External audit flagged Fenway coverage inaccuracies (independent of caching). Two of the four points were **stale-cache artifacts** on the auditor's side; two were **real data issues**. Verified from our side first.

### Caching (Task 1) — clean on our side
`curl https://theshadium.com/stadium/redsox`:
- `x-build-id = ebca87ef3eea` (current production), `<h1>` count = **1**, `age: 0`.
- No double-render, no missing meta. The auditor hit a stale cache.

### Real data fixes (independent of caching)
**Field Box 39-50, Loge Box 123-136, general SRO (Task 2):** RateYourSeats lists Fenway's covered seating as exactly the Pavilion Boxes, Home Plate Pavilion Club, Dell/EMC Club, and all Grandstand except GS-33. These three were wrongly `covered=true`. Reclassified to `covered=false` at the canonical source (also stops the 3D rows/shade endpoint modeling a non-existent overhang) and flagged as **partial "day games only (press-box shade)"** in the split UI — shaded for day games, but not covered structures. Remaining `covered=true` now matches the RateYourSeats list exactly.

**Monster Seats + Right Field Roof Box (Task 3):** already `covered=false` in current data (render **Exposed**) — the "good shade after 2nd inning" the auditor saw was the stale pre-#74 build (that text isn't in the current renderer at all). Confirmed, no change needed.

**Audit extension (Task 4):** `auditCoverageContradictions.ts` now has a **second pass** that cross-references every `covered=true` section against a researched covered-list (Fenway) — catching mislabeled non-open-air names (Field Box, Loge Box, SRO) that the open-air-name pass can't see. Both passes now report clean.

## Verification
- `tsc` clean · **666/666** tests (updated the 2 Fenway assertions to the corrected classification)
- production build (460 pages) OK
- both audit passes clean; built `/stadium/redsox` HTML shows FB/LB/SRO as day-shade partial and Monster Seats as Exposed

🤖 Generated with [Claude Code](https://claude.com/claude-code)