### PR TITLE
perf(R1) + shade diagram — Phase 1: per-venue data loading

### DIFF
--- a/app/stadium/[stadiumId]/StadiumPageClient.tsx
+++ b/app/stadium/[stadiumId]/StadiumPageClient.tsx
@@ -29,6 +29,9 @@ interface StadiumPageClientProps {
   sections: any[];
   amenities: any;
   guide: any;
+  // R1: precomputed fidelity note from the server, forwarded to the guide so no
+  // first-load client component imports the stadium-data-aggregator.
+  fidelityNote?: string | null;
   useComprehensive?: boolean;
 }
 
@@ -37,6 +40,7 @@ export default function StadiumPageClient({
   sections,
   amenities,
   guide,
+  fidelityNote,
   useComprehensive = false
 }: StadiumPageClientProps) {
   const [refreshKey, setRefreshKey] = useState(0);
@@ -136,7 +140,12 @@ export default function StadiumPageClient({
         >
           {/* Title block suppressed — StadiumPageSSR above renders the single
               page H1/header from the canonical stadium record. */}
-          <ComprehensiveStadiumGuide stadiumId={stadium.id} showTitleBlock={false} />
+          <ComprehensiveStadiumGuide
+            stadiumId={stadium.id}
+            guide={guide}
+            fidelityNote={fidelityNote}
+            showTitleBlock={false}
+          />
         </Suspense>
       </div>
 

--- a/app/stadium/[stadiumId]/page.tsx
+++ b/app/stadium/[stadiumId]/page.tsx
@@ -4,6 +4,11 @@ import { MLB_STADIUMS } from '../../../src/data/stadiums';
 import { getStadiumSectionsAsync } from '../../../src/data/getStadiumSections';
 import { getStadiumAmenities } from '../../../src/data/stadiumAmenities';
 import { getStadiumGuide } from '../../../src/data/guides';
+// R1: computed server-side so the venue page ships only the current venue's
+// guide/section/fidelity data — these full datasets never reach the client.
+import { getStadiumDataFidelity, fidelityNote } from '../../../src/data/stadiumDataFidelity';
+import { generateBaseballSections } from '../../../src/utils/generateBaseballSections';
+import { getVenueSections } from '../../../src/data/venueSections';
 import { getCanonicalStadiumId, needsRedirect } from '../../../src/utils/stadiumSlugMapping';
 import { ALL_UNIFIED_VENUES, getUnifiedVenueById } from '../../../src/data/unifiedVenues';
 import { bestShadedSideForDayGame } from '../../../src/utils/shadeSide';
@@ -283,6 +288,12 @@ export default async function StadiumPage({ params }: StadiumPageProps) {
       orientation: venue.orientation,
     });
 
+    // Per-venue data computed on the server (guide + approximate bowl geometry +
+    // fidelity note) so ComprehensiveStadiumGuide ships none of the full datasets.
+    const venueBowlSections = venue.league === 'MiLB'
+      ? generateBaseballSections(venue)
+      : getVenueSections(venue.id);
+
     return (
       <div className={styles.pageContainer}>
         {venueSchemas.map((schema, i) => (
@@ -293,7 +304,12 @@ export default async function StadiumPage({ params }: StadiumPageProps) {
             suppressHydrationWarning
           />
         ))}
-        <ComprehensiveStadiumGuide stadiumId={venue.id} />
+        <ComprehensiveStadiumGuide
+          stadiumId={venue.id}
+          guide={getStadiumGuide(venue.id)}
+          bowlSections={venueBowlSections as any}
+          fidelityNote={fidelityNote(getStadiumDataFidelity(venue.id))}
+        />
         <RelatedStadiums venueId={venue.id} />
         <ShadeDataVerified />
       </div>
@@ -305,6 +321,9 @@ export default async function StadiumPage({ params }: StadiumPageProps) {
   const amenities = getStadiumAmenities(stadium.id);
   // Use the stadium's canonical ID for guide lookup
   const guide = getStadiumGuide(stadium.id) || getStadiumGuide(stadiumId);
+  // Fidelity note computed on the server (was computed inside FidelityNotice,
+  // which pulled the full stadium-data-aggregator into the client first-load).
+  const fidelityNoteText = fidelityNote(getStadiumDataFidelity(stadium.id));
 
   // Structured data (Article + StadiumOrArena + FAQPage + BreadcrumbList),
   // built from the same helper the MiLB/NFL branch uses.
@@ -351,6 +370,7 @@ export default async function StadiumPage({ params }: StadiumPageProps) {
             sections={sections}
             amenities={amenities}
             guide={guide}
+            fidelityNote={fidelityNoteText}
             useComprehensive={!!guide}
           />
         </ErrorBoundary>

--- a/src/UnifiedApp.tsx
+++ b/src/UnifiedApp.tsx
@@ -10,6 +10,7 @@ import { EmptyState } from './components/EmptyStates';
 import { ErrorProvider, useError } from './components/ErrorNotification';
 import { Breadcrumb } from './components/Breadcrumb';
 import { FidelityNotice } from './components/FidelityNotice';
+import { getStadiumDataFidelity, fidelityNote } from './data/stadiumDataFidelity';
 import { LoadingSpinner } from './components/LoadingSpinner';
 import { VenueChangeSkeleton } from './components/SkeletonScreens';
 import { SunIcon, CloudIcon, ChartIcon, InfoIcon, MoonIcon, StadiumIcon, ShadeIcon, PartlyCloudyIcon, RainIcon } from './components/Icons';
@@ -333,7 +334,7 @@ function UnifiedAppContent() {
           {/* Honest disclosure for MLB parks whose seating data is templated.
               Gated to MLB — the fidelity classifier is MLB-specific. */}
           {selectedVenue?.league === 'MLB' && (
-            <FidelityNotice stadiumId={selectedVenue.id} />
+            <FidelityNotice note={fidelityNote(getStadiumDataFidelity(selectedVenue.id))} />
           )}
 
           {!selectedVenue && (

--- a/src/components/ComprehensiveStadiumGuide.tsx
+++ b/src/components/ComprehensiveStadiumGuide.tsx
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import { StadiumGuide } from '../data/stadiumGuides';
-import { getStadiumGuide } from '../data/guides';
 import { getUnifiedVenueById } from '../data/unifiedVenues';
 import Link from 'next/link';
 import {
@@ -17,20 +16,35 @@ import { StadiumTitleData } from './StadiumTitleBlock';
 import { FidelityNotice } from './FidelityNotice';
 import { ShadeAnswer } from './ShadeAnswer';
 import { InteractiveSeatingBowl } from './InteractiveSeatingBowl';
-import { generateBaseballSections } from '../utils/generateBaseballSections';
-import { getVenueSections } from '../data/venueSections';
 import type { StadiumSection } from '../data/stadiumSectionTypes';
 import './StadiumGuide.css';
 
 interface ComprehensiveStadiumGuideProps {
   stadiumId: string;
+  // R1: guide + bowl sections + fidelity note are passed in by the server (or an
+  // already-deferred client tree) instead of being looked up here. This keeps
+  // ComprehensiveStadiumGuide — which renders ssr:true and is therefore in the
+  // venue page's first-load bundle — from statically importing the full guides
+  // (3.1 MB), venueSections (0.73 MB) and stadium-data-aggregator (2.25 MB)
+  // datasets. The page loads only the current venue's data.
+  guide: StadiumGuide | undefined;
+  // Approximate seating-bowl geometry (generated for non-MLB); only used when
+  // showTitleBlock is true. Computed by the caller from the single venue.
+  bowlSections?: StadiumSection[];
+  // Precomputed fidelity note (see FidelityNotice). null/undefined = no note.
+  fidelityNote?: string | null;
   // When false, the guide's own title block (H1) is suppressed — used on MLB
   // stadium pages where StadiumPageSSR already renders the single H1/header.
   showTitleBlock?: boolean;
 }
 
-const ComprehensiveStadiumGuide: React.FC<ComprehensiveStadiumGuideProps> = ({ stadiumId, showTitleBlock = true }) => {
-  const guide = getStadiumGuide(stadiumId);
+const ComprehensiveStadiumGuide: React.FC<ComprehensiveStadiumGuideProps> = ({
+  stadiumId,
+  guide,
+  bowlSections: bowlSectionsProp,
+  fidelityNote,
+  showTitleBlock = true,
+}) => {
   // The structured venue record is the single source of truth for header
   // facts (location, capacity, orientation, league). Previously these came
   // from the guide's free-text neighborhood string, which produced the
@@ -78,14 +92,10 @@ const ComprehensiveStadiumGuide: React.FC<ComprehensiveStadiumGuideProps> = ({ s
     }
   };
 
-  // Approximate seating-bowl geometry for non-MLB venues: MiLB uses a generated
-  // ring; NFL uses the venueSections layout. This is generated data (not the
-  // section-by-section research MLB parks have), so the bowl is an approximation.
-  const bowlSections: StadiumSection[] = venue
-    ? ((venue.league === 'MiLB'
-        ? generateBaseballSections(venue)
-        : getVenueSections(venue.id)) as unknown as StadiumSection[])
-    : [];
+  // Approximate seating-bowl geometry for non-MLB venues (MiLB generated ring,
+  // NFL venueSections layout). Computed by the caller from the single venue so
+  // the full venueSections dataset never enters this first-load component.
+  const bowlSections: StadiumSection[] = bowlSectionsProp ?? [];
 
   return (
     <div className="stadium-guide comprehensive">
@@ -116,7 +126,7 @@ const ComprehensiveStadiumGuide: React.FC<ComprehensiveStadiumGuideProps> = ({ s
         />
       )}
 
-      <FidelityNotice stadiumId={stadiumId} />
+      <FidelityNotice note={fidelityNote} />
 
       {/* Overview Section */}
       <section className="guide-section">

--- a/src/components/FidelityNotice.tsx
+++ b/src/components/FidelityNotice.tsx
@@ -1,24 +1,28 @@
 import React from 'react';
-import { getStadiumDataFidelity, fidelityNote } from '../data/stadiumDataFidelity';
 import { InfoIcon } from './Icons';
 
 interface FidelityNoticeProps {
-  /** Canonical MLB stadium id. Pass null/undefined to render nothing. */
-  stadiumId: string | null | undefined;
+  /**
+   * Precomputed fidelity note text. Pass null/undefined to render nothing.
+   * Compute it with `fidelityNote(getStadiumDataFidelity(id))` from
+   * src/data/stadiumDataFidelity.ts — do that on the server (or in an
+   * already-deferred client tree) so the fidelity classifier (which pulls the
+   * full stadium-data-aggregator) never lands in a page's first-load bundle.
+   */
+  note: string | null | undefined;
 }
 
 /**
  * Subtle, honest disclosure for stadiums whose per-section seating data is
  * approximate (the auto-generated bowl template) rather than a real seating
- * map. Renders nothing for parks with real data. Single source of truth:
- * src/data/stadiumDataFidelity.ts.
+ * map. Renders nothing for parks with real data. Purely presentational now —
+ * the fidelity classification lives in src/data/stadiumDataFidelity.ts and is
+ * passed in as `note` by the caller.
  *
- * NOTE: the fidelity classifier is MLB-specific, so only render this in MLB
- * contexts (gate non-MLB callers, e.g. by venue.league === 'MLB').
+ * NOTE: the fidelity classifier is MLB-specific, so callers should only supply
+ * a note in MLB contexts (gate non-MLB callers, e.g. by venue.league === 'MLB').
  */
-export const FidelityNotice: React.FC<FidelityNoticeProps> = ({ stadiumId }) => {
-  if (!stadiumId) return null;
-  const note = fidelityNote(getStadiumDataFidelity(stadiumId));
+export const FidelityNotice: React.FC<FidelityNoticeProps> = ({ note }) => {
   if (!note) return null;
   return (
     <div


### PR DESCRIPTION
Combined R1 venue-data refactor + shade diagram, built in strict phases (see `R1-VENUE-DATA-REFACTOR.md`, `PERF-SCOPING.md §4`). **Phase 1 only so far — awaiting review at ⛔ Checkpoint 1.**

## Prerequisite check ✅
Rays 2026 = Tropicana Field (`roof: 'fixed'`, domed), not Steinbrenner; Athletics = Sutter Health Park (`open`); only Tropicana is `fixed`; Steinbrenner is a MiLB venue only. No wrong 2026 home/roof.

## Phase 1 — per-venue data loading
Venue pages statically pulled all ~240 venues' data into first-load JS through client components. Fixed by computing the single venue's data in the Server Component and passing it as props:
- `ComprehensiveStadiumGuide` no longer imports `guides` (3.05 MB) / `venueSections` / `generateBaseballSections` — receives `guide` + `bowlSections` props.
- `FidelityNotice` is now presentational (`note` prop); the fidelity classifier (which pulls `stadium-data-aggregator`, 2.25 MB) runs server-side.
- `page.tsx` computes guide + bowlSections + fidelity note per venue; `StadiumPageClient` forwards them; `UnifiedApp` computes its own note (already deferred).

### Results
| Metric | Before | After |
|---|---|---|
| **Venue First Load JS** | 439 kB | **191 kB (−56%)** |
| First-load `guides` | 3.05 MB | **0** |
| First-load `stadium-data-aggregator` | 2.25 MB | **0** |
| First-load `venueSections` | 0.73 MB | 0.73 MB (Phase 3) |
| Venue mobile Lighthouse (3-run median) | 74 (LCP 6.9 s) | **77 (LCP 6.3 s)** |

Modest Lighthouse gain despite the big JS cut because the venue LCP is now gated by the large SSR HTML document, not JS.

### Verification
- `type-check` clean · `npm test` **666/666**
- SSR intact — guide text + section tables present in raw server HTML for **MLB** (yankees), **MiLB** (las-vegas-aviators), **NFL** (metlife-stadium-giants), all HTTP 200.
- Visible SSR content **byte-identical** vs main (only a React render-marker nonce + JSON-LD build timestamp differ).

### Remaining / next
- `venueSections` (0.73 MB) still first-load via `StadiumPageSSR → InteractiveSeatingBowl → sunCalculations`. Deferred to Phase 3, where the shade diagram gets per-venue section props and the bowl's data path is decoupled.

Phases 2 (diagram feasibility) and 3 (diagram build) follow after review. Not squash-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)