### PR TITLE
chore: add Cursor Cloud environment for Next.js local setup

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,17 @@
+{
+  "name": "mlb-sun-tracker",
+  "install": "npm ci",
+  "terminals": [
+    {
+      "name": "dev-server",
+      "command": "npm run dev",
+      "description": "Next.js development server on http://localhost:3000"
+    }
+  ],
+  "ports": [
+    {
+      "name": "web",
+      "port": 3000
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# Agent instructions
+
+## Local development
+
+This is a Next.js 15 App Router app (The Shadium / MLB Stadium Sun Tracker).
+
+```bash
+npm ci
+npm run dev
+```
+
+The app listens on [http://localhost:3000](http://localhost:3000). No API keys are required to run locally. Weather uses the public Open-Meteo API. Analytics, Sentry, Airtable, and KV are optional and only needed for production features.
+
+## Useful commands
+
+- `npm test` — Jest unit tests
+- `npm run type-check` — TypeScript (`tsc --noEmit`)
+- `npm run lint` — ESLint
+- `npm run test:local` — Playwright visual + a11y checks against the local server
+
+## Cursor Cloud specific instructions
+
+`.cursor/environment.json` installs dependencies with `npm ci` and starts the Next.js dev server in a shared terminal. After boot, smoke-check:
+
+- `GET /` (homepage)
+- `GET /stadium/yankees` (canonical stadium page)
+- `GET /api/weather/yankees?lat=40.8296&lng=-73.9262` (Open-Meteo proxy)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a repository-managed Cursor Cloud environment so agents can install dependencies and run The Shadium locally.

## Changes
- `.cursor/environment.json` — `npm ci` on install, Next.js `npm run dev` in a shared terminal, port 3000
- `AGENTS.md` — local run commands, optional secrets, and smoke-check URLs

No application code changes. The app does not require API keys for local development (weather uses public Open-Meteo).

## Verification

Dependencies: `npm ci` (811 packages) on Node v22.14.0 / npm 10.9.7.

Dev server: `npm run dev` on http://localhost:3000

| Check | Result |
| --- | --- |
| `GET /` | 200, title "The Shadium - Find Seats in the Shade..." |
| `GET /stadium/yankees` | 200, Yankee Stadium shade guide |
| `GET /how-it-works` | 200, methodology page |
| `GET /api/weather/yankees` (no coords) | 400 as designed |
| `GET /api/weather/yankees?lat=40.8296&lng=-73.9262` | 200, current/hourly/daily Open-Meteo forecast |
| `GET /venue/yankees` | 301 → `/stadium/yankees` |
| Jest (`pageSmoke`, `stadiumShadeConfidence`, yankees inventory) | 81 tests passed |

Browser walkthrough:

[Homepage at localhost:3000](https://cursor.com/agents/bc-50e3389a-978b-4966-aea0-f3d076a3d173/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhomepage-hero.webp)
[Yankee Stadium shade guide](https://cursor.com/agents/bc-50e3389a-978b-4966-aea0-f3d076a3d173/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstadium-yankees.webp)
[How it works methodology page](https://cursor.com/agents/bc-50e3389a-978b-4966-aea0-f3d076a3d173/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhow-it-works.webp)

[shadium-local-dev-demo.mp4](https://cursor.com/agents/bc-50e3389a-978b-4966-aea0-f3d076a3d173/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshadium-local-dev-demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50e3389a-978b-4966-aea0-f3d076a3d173?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50e3389a-978b-4966-aea0-f3d076a3d173&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

