### PR TITLE
chore: add Cloud Agent dev environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,17 @@
+{
+  "name": "MLB Sun Tracker",
+  "install": "npm ci",
+  "terminals": [
+    {
+      "name": "next-dev",
+      "command": "npm run dev",
+      "description": "Next.js development server on http://localhost:3000"
+    }
+  ],
+  "ports": [
+    {
+      "name": "web",
+      "port": 3000
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `.cursor/environment.json` so Cloud Agents get a ready-to-use development environment for this Next.js app (The Shadium — MLB/NFL/MiLB stadium sun/shade tracker).

The config:
- `install`: `npm ci` — deterministic dependency install from the committed `package-lock.json`.
- `terminals`: launches `npm run dev` (Next.js dev server on port 3000) so the running app is visible to the agent.
- `ports`: exposes port `3000`.

The default Cloud Agent image already provides Node.js 22, which satisfies Next.js 15, so no custom Dockerfile is required.

## Validation

All of the following were run end-to-end on a fresh checkout in this environment:

- `npm ci` — installed 811 packages, exit 0.
- `npm run dev` — Next.js 15.5.23 ready; `GET /` returns HTTP 200.
- `npm run type-check` — `tsc --noEmit` passed, exit 0.
- `npm test` — 42 suites, 1097 tests passed, exit 0.
- `npm run build` — full production build (sitemap generation + `next build` + Brotli/Gzip compression) succeeded, exit 0.
- Prebuilt environment build — a draft build of this environment succeeded with `install` (`npm ci`) completing cleanly, confirming the config works with Cursor environment builds.

### End-to-end browser demo

Selected Dodger Stadium and an upcoming game; the app computed and rendered sun position, sun visibility, and the weather/hourly forecast with no errors.

[shadium_app_clean_demo.mp4](https://cursor.com/agents/bc-47739c4c-e5fc-4360-b74f-894a81387483/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshadium_app_clean_demo.mp4)

[The Shadium landing page](https://cursor.com/agents/bc-47739c4c-e5fc-4360-b74f-894a81387483/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshadium_landing_clean.webp)

[Sun and weather analysis results for Dodger Stadium](https://cursor.com/agents/bc-47739c4c-e5fc-4360-b74f-894a81387483/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshadium_results_clean.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47739c4c-e5fc-4360-b74f-894a81387483?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47739c4c-e5fc-4360-b74f-894a81387483&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

